### PR TITLE
Split enableReferenceAxisLines into two properties

### DIFF
--- a/Classes/BEMSimpleLineGraphView.h
+++ b/Classes/BEMSimpleLineGraphView.h
@@ -170,11 +170,14 @@
 @property (nonatomic) BOOL autoScaleYAxis;
 
 
-/// Draws a translucent vertical lines along the graph for each X-Axis label, when set to YES. Default value is NO.
-@property (nonatomic) BOOL enableReferenceAxisLines;
+/// Draws a translucent vertical lines along the graph for each X-Axis when set to YES. Default value is NO.
+@property (nonatomic) BOOL enableReferenceXAxisLines;
+
+/// Draws a translucent horizontal lines along the graph for each Y-Axis label, when set to YES. Default value is NO.
+@property (nonatomic) BOOL enableReferenceYAxisLines;
 
 /** Draws a translucent frame between the graph and any enabled axis, when set to YES. Default value is NO.
- @see enableReferenceAxisLines must be set to YES for this property to have any affect.  */
+ @see enableReferenceXAxisLines or enableReferenceYAxisLines must be set to YES for this property to have any affect.  */
 @property (nonatomic) BOOL enableReferenceAxisFrame;
 
 

--- a/Classes/BEMSimpleLineGraphView.m
+++ b/Classes/BEMSimpleLineGraphView.m
@@ -437,13 +437,12 @@
     } else {
         line.xAxisBackgroundColor = self.colorBackgroundXaxis;
     }
-    if (self.enableReferenceAxisLines == YES) {
-        if (self.enableReferenceAxisFrame) line.enableRefrenceFrame = YES;
-        else line.enableRefrenceFrame = NO;
+    if (self.enableReferenceXAxisLines || self.enableReferenceYAxisLines) {
+        line.enableRefrenceFrame = self.enableReferenceAxisFrame;
         
         line.enableRefrenceLines = YES;
-        line.arrayOfVerticalRefrenceLinePoints = xAxisLabelPoints;
-        line.arrayOfHorizontalRefrenceLinePoints = yAxisLabelPoints;
+        line.arrayOfVerticalRefrenceLinePoints = self.enableReferenceXAxisLines ? xAxisLabelPoints : nil;
+        line.arrayOfHorizontalRefrenceLinePoints = self.enableReferenceYAxisLines ? yAxisLabelPoints : nil;
     }
     
     line.frameOffset = self.XAxisLabelYOffset;

--- a/Sample Project/SimpleLineChart/ViewController.m
+++ b/Sample Project/SimpleLineChart/ViewController.m
@@ -57,7 +57,8 @@
     self.myGraph.enableYAxisLabel = YES;
     self.myGraph.autoScaleYAxis = YES;
     self.myGraph.alwaysDisplayDots = NO;
-    self.myGraph.enableReferenceAxisLines = YES;
+    self.myGraph.enableReferenceXAxisLines = YES;
+    self.myGraph.enableReferenceYAxisLines = YES;
     self.myGraph.enableReferenceAxisFrame = YES;
     self.myGraph.animationGraphStyle = BEMLineAnimationDraw;
     


### PR DESCRIPTION
Allow individual specifying of just X, Y or both reference lines.

This closes #69
