### PR TITLE
Add optional delegate methods for dot display and color

### DIFF
--- a/Classes/BEMSimpleLineGraphView.h
+++ b/Classes/BEMSimpleLineGraphView.h
@@ -353,11 +353,22 @@
 - (NSString *)popUpSuffixForlineGraph:(BEMSimpleLineGraphView *)graph;
 
 /** Optional method to always display some of the pop up labels on the graph.
- @see alwaysDisplayPopUpLabels must be set to YES for this method to have any affect.
+ @see alwaysDisplayPopUpLabels must be set to YES for this method to have any effect.
  @param graph The graph object requesting the total number of points.
  @param index The index from left to right of the points on the graph. The first value for the index is 0.
  @return Return YES if you want the popup label to be displayed for this index. */
 - (BOOL)lineGraph:(BEMSimpleLineGraphView *)graph alwaysDisplayPopUpAtIndex:(CGFloat)index;
+
+/** Optional method to always display some dots on the graph.
+ @see alwaysDisplayDots must be set to YES for this method to have any effect.
+ @param index The index from left to right of the points on the graph. The first value for the index is 0.
+ @return YES if a pop up label should be displayed for this index. */
+- (BOOL)lineGraph:(BEMSimpleLineGraphView *)graph alwaysDisplayDotAtIndex:(NSInteger)index;
+
+/** Optional method to alter the color of dots on the graph.
+ @param index The index from left to right of the points on the graph. The first value for the index is 0.
+ @return a color or nil. A value of nil defaults the dot color to \p colorPoint */
+- (UIColor*)lineGraph:(BEMSimpleLineGraphView *)graph colorForDotAtIndex:(NSInteger)index;
 
 /** Optional method to set the maximum value of the Y-Axis. If not implemented, the maximum value will be the biggest point of the graph.
  @param graph The graph object requesting the maximum value.

--- a/Classes/BEMSimpleLineGraphView.m
+++ b/Classes/BEMSimpleLineGraphView.m
@@ -132,7 +132,7 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
     _colorTop = [UIColor colorWithRed:0 green:122.0/255.0 blue:255/255 alpha:1];
     _colorLine = [UIColor colorWithRed:255.0/255.0 green:255.0/255.0 blue:255.0/255.0 alpha:1];
     _colorBottom = [UIColor colorWithRed:0 green:122.0/255.0 blue:255/255 alpha:1];
-    _colorPoint = [UIColor whiteColor];
+    _colorPoint = [UIColor colorWithWhite:1.0 alpha:0.7];
     _colorTouchInputLine = [UIColor grayColor];
     _colorBackgroundPopUplabel = [UIColor whiteColor];
     _alphaTouchInputLine = 0.2;
@@ -398,7 +398,10 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
             circleDot.tag = i+ DotFirstTag100;
             circleDot.alpha = 0;
             circleDot.absoluteValue = dotValue;
-            circleDot.Pointcolor = self.colorPoint;
+            UIColor* pointColor = self.colorPoint;
+            if ([self.delegate respondsToSelector:@selector(lineGraph:colorForDotAtIndex:)])
+                pointColor = [self.delegate lineGraph:self colorForDotAtIndex:i] ?: pointColor;
+            circleDot.Pointcolor = pointColor;
             
             [self addSubview:circleDot];
             
@@ -411,15 +414,17 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
             }
             
             // Dot entrance animation
+            BOOL shouldDisplayDot = self.alwaysDisplayDots;
+            if (shouldDisplayDot && [self.delegate respondsToSelector:@selector(lineGraph:alwaysDisplayDotAtIndex:)])
+                shouldDisplayDot = [self.delegate lineGraph:self alwaysDisplayDotAtIndex:i];
+
             if (self.animationGraphEntranceTime == 0) {
-                if (self.alwaysDisplayDots == NO) {
-                    circleDot.alpha = 0;  // never reach here
-                } else circleDot.alpha = 0.7;
+                circleDot.alpha = shouldDisplayDot ? 1.0 : 0;
             } else {
                 [UIView animateWithDuration:(float)self.animationGraphEntranceTime/numberOfPoints delay:(float)i*((float)self.animationGraphEntranceTime/numberOfPoints) options:UIViewAnimationOptionCurveLinear animations:^{
-                    circleDot.alpha = 0.7;
+                    circleDot.alpha = 1.0;
                 } completion:^(BOOL finished) {
-                    if (self.alwaysDisplayDots == NO) {
+                    if (!shouldDisplayDot) {
                         [UIView animateWithDuration:0.3 delay:0 options:UIViewAnimationOptionCurveEaseOut animations:^{
                             circleDot.alpha = 0;
                         } completion:nil];

--- a/Sample Project/SimpleLineChart/ViewController.m
+++ b/Sample Project/SimpleLineChart/ViewController.m
@@ -64,7 +64,7 @@
     self.myGraph.enableBezierCurve = YES;
     self.myGraph.enableYAxisLabel = YES;
     self.myGraph.autoScaleYAxis = YES;
-    self.myGraph.alwaysDisplayDots = NO;
+    self.myGraph.alwaysDisplayDots = YES;
     self.myGraph.enableReferenceXAxisLines = YES;
     self.myGraph.enableReferenceYAxisLines = YES;
     self.myGraph.enableReferenceAxisFrame = YES;
@@ -172,6 +172,22 @@
 - (NSString *)lineGraph:(BEMSimpleLineGraphView *)graph labelOnXAxisForIndex:(NSInteger)index {
     NSString *label = [self.arrayOfDates objectAtIndex:index];
     return [label stringByReplacingOccurrencesOfString:@" " withString:@"\n"];
+}
+
+- (UIColor *)lineGraph:(BEMSimpleLineGraphView *)graph colorForDotAtIndex:(NSInteger)index {
+    switch (index) {
+        case 0:
+            return [UIColor redColor];
+
+        case 2:
+            return [UIColor blueColor];
+        default:
+            return nil;
+    }
+}
+
+- (BOOL)lineGraph:(BEMSimpleLineGraphView *)graph alwaysDisplayDotAtIndex:(NSInteger)index {
+    return index % 2 == 0;
 }
 
 - (void)lineGraph:(BEMSimpleLineGraphView *)graph didTouchGraphWithClosestIndex:(NSInteger)index {


### PR DESCRIPTION
## Additions

Added two delegate methods, `lineGraph:alwaysDisplayDotAtIndex:` and `lineGraph:colorForDotAtIndex:`. 

*  `lineGraph:alwaysDisplayDotAtIndex:` requires the property `alwaysDisplayDots` to be `YES` in order to be used.
* `lineGraph:colorForDotAtIndex:` is used during the entrance animation as well, and does not require `alwaysDisplayDots`. If `nil` is provided for this value, the default is `colorPoint`.

## Changes

* Changed the default dot alpha to `1.0` instead of `0.7`, and instead set the default dot color to `[UIColor colorWithWhite:1.0 alpha:0.7]`. This way, a user can specify full opacity or other alpha values for dots. However, this is a possibly breaking change for existing users dependent on `0.7` as the dot alpha value.
* Added an example usage to the sample project

I'm not sure if the sample usage is necessary, I can make a wiki update instead.