### PR TITLE
Ensure permanent pop-up labels are not duplicated

### DIFF
--- a/Classes/BEMPermanentPopupView.h
+++ b/Classes/BEMPermanentPopupView.h
@@ -1,0 +1,13 @@
+//
+//  BEMPermanentPopupView.h
+//  SimpleLineGraph
+//
+//  Created by Delisa Mason on 1/29/15.
+//  Copyright (c) 2015 Boris Emorine. All rights reserved.
+//
+
+#import <UIKit/UIKit.h>
+
+@interface BEMPermanentPopupView : UIView
+
+@end

--- a/Classes/BEMPermanentPopupView.m
+++ b/Classes/BEMPermanentPopupView.m
@@ -1,0 +1,13 @@
+//
+//  BEMPermanentPopupView.m
+//  SimpleLineGraph
+//
+//  Created by Delisa Mason on 1/29/15.
+//  Copyright (c) 2015 Boris Emorine. All rights reserved.
+//
+
+#import "BEMPermanentPopupView.h"
+
+@implementation BEMPermanentPopupView
+
+@end

--- a/Classes/BEMSimpleLineGraphView.h
+++ b/Classes/BEMSimpleLineGraphView.h
@@ -20,7 +20,7 @@
 
 #import "BEMCircle.h"
 #import "BEMLine.h"
-
+#import "BEMPermanentPopupView.h"
 
 @protocol BEMSimpleLineGraphDelegate;
 @protocol BEMSimpleLineGraphDataSource;

--- a/Classes/BEMSimpleLineGraphView.m
+++ b/Classes/BEMSimpleLineGraphView.m
@@ -352,7 +352,7 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
     
     // Remove all dots that were previously on the graph
     for (UIView *subview in [self subviews]) {
-        if ([subview isKindOfClass:[BEMCircle class]])
+        if ([subview isKindOfClass:[BEMCircle class]] || [subview isKindOfClass:[BEMPermanentPopupView class]])
             [subview removeFromSuperview];
     }
     
@@ -776,8 +776,7 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
     [permanentPopUpLabel sizeToFit];
     permanentPopUpLabel.center = CGPointMake(self.xCenterLabel, circleDot.center.y - circleDot.frame.size.height/2 - 15);
     permanentPopUpLabel.alpha = 0;
-    
-    UIView *permanentPopUpView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, permanentPopUpLabel.frame.size.width + 7, permanentPopUpLabel.frame.size.height + 2)];
+    BEMPermanentPopupView *permanentPopUpView = [[BEMPermanentPopupView alloc] initWithFrame:CGRectMake(0, 0, permanentPopUpLabel.frame.size.width + 7, permanentPopUpLabel.frame.size.height + 2)];
     permanentPopUpView.backgroundColor = [UIColor whiteColor];
     permanentPopUpView.alpha = 0;
     permanentPopUpView.layer.cornerRadius = 3;

--- a/Sample Project/SimpleLineChart.xcodeproj/project.pbxproj
+++ b/Sample Project/SimpleLineChart.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8AB8D62F1A7ABDF600FC4AEC /* BEMPermanentPopupView.m in Sources */ = {isa = PBXBuildFile; fileRef = 8AB8D62E1A7ABDF600FC4AEC /* BEMPermanentPopupView.m */; };
 		99B15643187B412400B24591 /* StatsViewController.m in Sources */ = {isa = PBXBuildFile; fileRef = 99B15642187B412400B24591 /* StatsViewController.m */; };
 		99B3FA3A1877898B00539A7B /* LICENSE in Resources */ = {isa = PBXBuildFile; fileRef = 99B3FA381877898B00539A7B /* LICENSE */; };
 		99B3FA3B1877898B00539A7B /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 99B3FA391877898B00539A7B /* README.md */; };
@@ -40,6 +41,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		8AB8D62D1A7ABDF600FC4AEC /* BEMPermanentPopupView.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BEMPermanentPopupView.h; sourceTree = "<group>"; };
+		8AB8D62E1A7ABDF600FC4AEC /* BEMPermanentPopupView.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BEMPermanentPopupView.m; sourceTree = "<group>"; };
 		99B15641187B412400B24591 /* StatsViewController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = StatsViewController.h; sourceTree = "<group>"; };
 		99B15642187B412400B24591 /* StatsViewController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = StatsViewController.m; sourceTree = "<group>"; };
 		99B3FA381877898B00539A7B /* LICENSE */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = LICENSE; path = ../LICENSE; sourceTree = "<group>"; };
@@ -104,6 +107,8 @@
 				C3B90A59187D15F7003E407D /* BEMCircle.m */,
 				C3B90A5A187D15F7003E407D /* BEMLine.h */,
 				C3B90A5B187D15F7003E407D /* BEMLine.m */,
+				8AB8D62D1A7ABDF600FC4AEC /* BEMPermanentPopupView.h */,
+				8AB8D62E1A7ABDF600FC4AEC /* BEMPermanentPopupView.m */,
 			);
 			name = Classes;
 			path = ../Classes;
@@ -290,6 +295,7 @@
 				C3B90A5F187D15F7003E407D /* BEMCircle.m in Sources */,
 				C3FD816F186DFD9A00FD8ED3 /* ViewController.m in Sources */,
 				C3B90A60187D15F7003E407D /* BEMLine.m in Sources */,
+				8AB8D62F1A7ABDF600FC4AEC /* BEMPermanentPopupView.m in Sources */,
 				C3FD8169186DFD9A00FD8ED3 /* AppDelegate.m in Sources */,
 				99B15643187B412400B24591 /* StatsViewController.m in Sources */,
 				C3FD8165186DFD9A00FD8ED3 /* main.m in Sources */,


### PR DESCRIPTION
When the graph is redrawn with a different frame and permanent pop up labels are present, they are never removed between layouts. This change ensures the permanent labels are removed instead of duplicated. 

Fixes #74 

## Changes

* Add a class for permanent popup labels, `BEMPermanentPopupView`
* Remove permanent labels when laying out dots