### PR TITLE
Allow coloring pop-up label background and foreground

### DIFF
--- a/Classes/BEMSimpleLineGraphView.h
+++ b/Classes/BEMSimpleLineGraphView.h
@@ -279,6 +279,8 @@
 /// Color of the pop up label's background displayed when the user touches the graph.
 @property (strong, nonatomic) UIColor *colorBackgroundPopUplabel;
 
+/// Color of the pop up label's foreground displayed when the user touches the graph.
+@property (strong, nonatomic) UIColor *colorForegroundPopUpLabel;
 
 @end
 
@@ -351,6 +353,12 @@
  @param graph The graph object requesting the total number of points.
  @return The suffix to append to the popup report. */
 - (NSString *)popUpSuffixForlineGraph:(BEMSimpleLineGraphView *)graph;
+
+/** Optional method to set the text color of the pop up labels on the graph.
+ @param graph The graph object requesting the pop up label color.
+ @param index The index from left to right of the points on the graph. The first value for the index is 0.
+ @return A color or nil. When nil, the default value of \p colorForegroundPopUpLabel is used */
+- (UIColor *)lineGraph:(BEMSimpleLineGraphView *)graph colorForPopUpAtIndex:(NSInteger)index;
 
 /** Optional method to always display some of the pop up labels on the graph.
  @see alwaysDisplayPopUpLabels must be set to YES for this method to have any affect.

--- a/Sample Project/SimpleLineChart/ViewController.m
+++ b/Sample Project/SimpleLineChart/ViewController.m
@@ -64,11 +64,13 @@
     self.myGraph.enableBezierCurve = YES;
     self.myGraph.enableYAxisLabel = YES;
     self.myGraph.autoScaleYAxis = YES;
+    self.myGraph.alwaysDisplayPopUpLabels = YES;
     self.myGraph.alwaysDisplayDots = NO;
     self.myGraph.enableReferenceXAxisLines = YES;
     self.myGraph.enableReferenceYAxisLines = YES;
     self.myGraph.enableReferenceAxisFrame = YES;
     self.myGraph.animationGraphStyle = BEMLineAnimationDraw;
+    self.myGraph.colorBackgroundPopUplabel = [UIColor clearColor];
     
     //setup initial selectet segment
     self.curveChoice.selectedSegmentIndex = self.myGraph.enableBezierCurve;
@@ -197,6 +199,16 @@
 - (void)lineGraphDidFinishLoading:(BEMSimpleLineGraphView *)graph {
     self.labelValues.text = [NSString stringWithFormat:@"%i", [[self.myGraph calculatePointValueSum] intValue]];
     self.labelDates.text = [NSString stringWithFormat:@"between %@ and %@", [self.arrayOfDates firstObject], [self.arrayOfDates lastObject]];
+}
+
+- (BOOL)lineGraph:(BEMSimpleLineGraphView *)graph alwaysDisplayPopUpAtIndex:(CGFloat)index {
+    return ((int)index % 6) == 0;
+}
+
+- (UIColor *)lineGraph:(BEMSimpleLineGraphView *)graph colorForPopUpAtIndex:(NSInteger)index {
+    if (index % 3 == 0)
+        return [UIColor colorWithWhite:0.3 alpha:1.0];
+    return nil;
 }
 
 @end


### PR DESCRIPTION
## Additions

* Add property `colorForegroundPopupLabel` for coloring pop up label text. The default color is black.
* Add delegate method `lineGraph:colorForPopupAtIndex` for coloring specific indices

## Changes

* Use `colorBackgroundPopuplabel` for the permanent pop up label background color. Fixes #120.
* Set default label background to `1.0` instead of `0.7` and use `[UIColor colorWithWhite:1 alpha:0.7]` as the default color instead, to allow the user to change the alpha value.

I'm not sure if the sample usage is necessary, I can make a wiki update instead.