### PR TITLE
Fixes issue with duplicate pop up labels being displayed

### DIFF
--- a/Classes/BEMPermanentPopupView.h
+++ b/Classes/BEMPermanentPopupView.h
@@ -11,3 +11,7 @@
 @interface BEMPermanentPopupView : UIView
 
 @end
+
+@interface BEMPermanentPopupLabel : UILabel
+
+@end

--- a/Classes/BEMPermanentPopupView.m
+++ b/Classes/BEMPermanentPopupView.m
@@ -11,3 +11,7 @@
 @implementation BEMPermanentPopupView
 
 @end
+
+@implementation BEMPermanentPopupLabel
+
+@end

--- a/Classes/BEMSimpleLineGraphView.m
+++ b/Classes/BEMSimpleLineGraphView.m
@@ -464,7 +464,7 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
     
     // Remove all dots that were previously on the graph
     for (UIView *subview in [self subviews]) {
-        if ([subview isKindOfClass:[BEMCircle class]] || [subview isKindOfClass:[BEMPermanentPopupView class]])
+        if ([subview isKindOfClass:[BEMCircle class]] || [subview isKindOfClass:[BEMPermanentPopupView class]] || [subview isKindOfClass:[BEMPermanentPopupLabel class]])
             [subview removeFromSuperview];
     }
     
@@ -1080,12 +1080,13 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
     self.enablePopUpReport = NO;
     self.xCenterLabel = circleDot.center.x;
     
-    UILabel *permanentPopUpLabel = [[UILabel alloc] init];
+    BEMPermanentPopupLabel *permanentPopUpLabel = [[BEMPermanentPopupLabel alloc] init];
     permanentPopUpLabel.textAlignment = NSTextAlignmentCenter;
     permanentPopUpLabel.numberOfLines = 0;
     
     NSString *prefix = @"";
     NSString *suffix = @"";
+    
     if ([self.delegate respondsToSelector:@selector(popUpSuffixForlineGraph:)])
         suffix = [self.delegate popUpSuffixForlineGraph:self];
 


### PR DESCRIPTION
This PR fixes an issue where pop up labels appear twice after screen orientation changes. 

PS: To reproduce the issue set pop up labels to be always visible and change your device's screen orientation. This causes layoutSubview to be called and the existing pop up labels are left on screen while new ones are also created, causing them to appear duplicated.
