### PR TITLE
Fix static analyser warning about uninitialized struct

### DIFF
--- a/Classes/BEMLine.m
+++ b/Classes/BEMLine.m
@@ -172,8 +172,8 @@
         }
     }
     
-    CGPoint previousPoint1;
-    CGPoint previousPoint2;
+    CGPoint previousPoint1 = CGPointMake(0,0);
+    CGPoint previousPoint2 = CGPointMake(0,0);
     
     for (int i = 0; i < points.count - 1; i++) {
         p1 = [[points objectAtIndex:i] CGPointValue];


### PR DESCRIPTION
Quick fix for a static analyser warning about the previous point structs not being initialized.

![screen shot 2015-06-22 at 10 10 21 pm](https://cloud.githubusercontent.com/assets/409207/8281492/d4b6d096-192b-11e5-9b57-0d4a0e568f15.png)
