### PR TITLE
Removing tag dependency and restructuring.

### DIFF
--- a/Classes/BEMAverageLine.h
+++ b/Classes/BEMAverageLine.h
@@ -19,7 +19,7 @@
 
 
 /// The color of the average line
-@property (strong, nonatomic) UIColor *color;
+@property (strong, nonatomic, nonnull) UIColor *color;
 
 
 /// The Y-Value of the average line. This could be an average, a median, a mode, sum, etc.
@@ -35,7 +35,14 @@
 
 
 /// Dash pattern for the average line
-@property (strong, nonatomic) NSArray *dashPattern;
+@property (strong, nonatomic, nullable) NSArray *dashPattern;
 
+
+//Label for average line in y axis. Default is blank.
+@property (strong, nonatomic, nullable) NSString * title;
+
+
+/// Title label on screen
+@property (strong, nonatomic, nullable) UILabel *label;
 
 @end

--- a/Classes/BEMAverageLine.m
+++ b/Classes/BEMAverageLine.m
@@ -17,10 +17,19 @@
         _color = [UIColor whiteColor];
         _alpha = 1.0;
         _width = 3.0;
-        _yValue = 0.0;
+        _yValue = NAN;
     }
     
     return self;
 }
+-(void) setLabel:(UILabel *)label {
+    if (_label != label) {
+        [_label removeFromSuperview];
+        _label = label;
+    }
+}
 
+-(void) dealloc {
+    self.label= nil;
+}
 @end

--- a/Classes/BEMCircle.h
+++ b/Classes/BEMCircle.h
@@ -19,11 +19,11 @@
 @property (assign, nonatomic) BOOL shouldDisplayConstantly;
 
 /// The point's color
-@property (strong, nonatomic) UIColor *color;
+@property (strong, nonatomic, nullable) UIColor *color;
 
 /** The point color
  @deprecated This property is no longer in use. Please use the \p color property instead. */
-@property (strong, nonatomic) UIColor *Pointcolor __deprecated_msg("Use color instead");
+@property (strong, nonatomic, null_unspecified) UIColor *Pointcolor __deprecated_msg("Use color instead");
 
 /// The value of the point
 @property (nonatomic) CGFloat absoluteValue;

--- a/Classes/BEMLine.h
+++ b/Classes/BEMLine.h
@@ -43,26 +43,26 @@ typedef NS_ENUM(NSUInteger, BEMLineGradientDirection) {
 //----- POINTS -----//
 
 /// All of the Y-axis values for the points
-@property (strong, nonatomic) NSArray *arrayOfPoints;
+@property (strong, nonatomic, nonnull) NSArray *arrayOfPoints;
 
 /// All of the X-Axis coordinates used to draw vertical lines through
-@property (strong, nonatomic) NSArray *arrayOfVerticalRefrenceLinePoints;
+@property (strong, nonatomic, nonnull) NSArray *arrayOfVerticalReferenceLinePoints;
 
 /// The value used to offset the fringe vertical reference lines when the x-axis labels are on the edge
 @property (assign, nonatomic) CGFloat verticalReferenceHorizontalFringeNegation;
 
 /// All of the Y-Axis coordinates used to draw horizontal lines through
-@property (strong, nonatomic) NSArray *arrayOfHorizontalRefrenceLinePoints;
+@property (strong, nonatomic, nullable) NSArray *arrayOfHorizontalReferenceLinePoints;
 
 /// All of the point values
-@property (strong, nonatomic) NSArray *arrayOfValues;
+@property (strong, nonatomic, nullable) NSArray *arrayOfValues;
 
 /** Draw thin, translucent, reference lines using the provided X-Axis and Y-Axis coordinates.
- @see Use \p arrayOfVerticalRefrenceLinePoints to specify vertical reference lines' positions. Use \p arrayOfHorizontalRefrenceLinePoints to specify horizontal reference lines' positions. */
-@property (assign, nonatomic) BOOL enableRefrenceLines;
+ @see Use \p arrayOfVerticalReferenceLinePoints to specify vertical reference lines' positions. Use \p arrayOfHorizontalReferenceLinePoints to specify horizontal reference lines' positions. */
+@property (assign, nonatomic) BOOL enableReferenceLines;
 
 /** Draw a thin, translucent, frame on the edge of the graph to separate it from the labels on the X-Axis and the Y-Axis. */
-@property (assign, nonatomic) BOOL enableRefrenceFrame;
+@property (assign, nonatomic) BOOL enableReferenceFrame;
 
 /** If reference frames are enabled, this will enable/disable specific borders.  Default: YES */
 @property (assign, nonatomic) BOOL enableLeftReferenceFrameLine;
@@ -77,10 +77,10 @@ typedef NS_ENUM(NSUInteger, BEMLineGradientDirection) {
 @property (assign, nonatomic) BOOL enableTopReferenceFrameLine;
 
 /** Dash pattern for the references line on the X axis */
-@property (nonatomic, strong) NSArray *lineDashPatternForReferenceXAxisLines;
+@property (nonatomic, strong, nullable) NSArray *lineDashPatternForReferenceXAxisLines;
 
 /** Dash pattern for the references line on the Y axis */
-@property (nonatomic, strong) NSArray *lineDashPatternForReferenceYAxisLines;
+@property (nonatomic, strong, nullable) NSArray *lineDashPatternForReferenceYAxisLines;
 
 /** If a null value is present, interpolation would draw a best fit line through the null point bound by its surrounding points.  Default: YES */
 @property (assign, nonatomic) BOOL interpolateNullValues;
@@ -93,51 +93,51 @@ typedef NS_ENUM(NSUInteger, BEMLineGradientDirection) {
 //----- COLORS -----//
 
 /// The line color. A single, solid color which is applied to the entire line. If the \p gradient property is non-nil this property will be ignored.
-@property (strong, nonatomic) UIColor *color;
+@property (strong, nonatomic, nullable) UIColor *color;
 
 /// The color of the area above the line, inside of its superview
-@property (strong, nonatomic) UIColor *topColor;
+@property (strong, nonatomic, nullable) UIColor *topColor;
 
 /// A color gradient applied to the area above the line, inside of its superview. If set, it will be drawn on top of the fill from the \p topColor property.
-@property (assign, nonatomic) CGGradientRef topGradient;
+@property (assign, nonatomic, nullable) CGGradientRef topGradient;
 
 /// The color of the area below the line, inside of its superview
-@property (strong, nonatomic) UIColor *bottomColor;
+@property (strong, nonatomic, nullable) UIColor *bottomColor;
 
 /// A color gradient applied to the area below the line, inside of its superview. If set, it will be drawn on top of the fill from the \p bottomColor property.
-@property (assign, nonatomic) CGGradientRef bottomGradient;
+@property (assign, nonatomic, nullable) CGGradientRef bottomGradient;
 
 /// A color gradient to be applied to the line. If this property is set, it will mask (override) the \p color property.
-@property (assign, nonatomic) CGGradientRef lineGradient;
+@property (assign, nonatomic, nullable) CGGradientRef lineGradient;
 
 /// The drawing direction of the line gradient color
 @property (nonatomic) BEMLineGradientDirection lineGradientDirection;
 
 /// The reference line color. Defaults to `color`.
-@property (strong, nonatomic) UIColor *refrenceLineColor;
+@property (strong, nonatomic, nullable) UIColor *referenceLineColor;
 
 
 
 //----- ALPHA -----//
 
 /// The line alpha
-@property (assign, nonatomic) float lineAlpha;
+@property (assign, nonatomic) CGFloat lineAlpha;
 
 /// The alpha value of the area above the line, inside of its superview
-@property (assign, nonatomic) float topAlpha;
+@property (assign, nonatomic) CGFloat topAlpha;
 
 /// The alpha value of the area below the line, inside of its superview
-@property (assign, nonatomic) float bottomAlpha;
+@property (assign, nonatomic) CGFloat bottomAlpha;
 
 
 
 //----- SIZE -----//
 
 /// The width of the line
-@property (assign, nonatomic) float lineWidth;
+@property (assign, nonatomic) CGFloat lineWidth;
 
 /// The width of a reference line
-@property (nonatomic) float referenceLineWidth;
+@property (nonatomic) CGFloat referenceLineWidth;
 
 
 
@@ -161,7 +161,7 @@ typedef NS_ENUM(NSUInteger, BEMLineGradientDirection) {
 //----- AVERAGE -----//
 
 /// The average line
-@property (strong, nonatomic) BEMAverageLine *averageLine;
+@property (strong, nonatomic, nullable) BEMAverageLine *averageLine;
 
 /// The average line's y-value translated into the coordinate system
 @property (assign, nonatomic) CGFloat averageLineYCoordinate;

--- a/Classes/BEMLine.m
+++ b/Classes/BEMLine.m
@@ -39,22 +39,24 @@
 
 - (void)drawRect:(CGRect)rect {
     //----------------------------//
-    //---- Draw Refrence Lines ---//
+    //---- Draw Reference Lines ---//
     //----------------------------//
+    self.layer.sublayers = nil;
+
     UIBezierPath *verticalReferenceLinesPath = [UIBezierPath bezierPath];
     UIBezierPath *horizontalReferenceLinesPath = [UIBezierPath bezierPath];
     UIBezierPath *referenceFramePath = [UIBezierPath bezierPath];
 
     verticalReferenceLinesPath.lineCapStyle = kCGLineCapButt;
-    verticalReferenceLinesPath.lineWidth = 0.7;
+    verticalReferenceLinesPath.lineWidth = 0.7f;
 
     horizontalReferenceLinesPath.lineCapStyle = kCGLineCapButt;
-    horizontalReferenceLinesPath.lineWidth = 0.7;
+    horizontalReferenceLinesPath.lineWidth = 0.7f;
 
     referenceFramePath.lineCapStyle = kCGLineCapButt;
-    referenceFramePath.lineWidth = 0.7;
+    referenceFramePath.lineWidth = 0.7f;
 
-    if (self.enableRefrenceFrame == YES) {
+    if (self.enableReferenceFrame == YES) {
         if (self.enableBottomReferenceFrameLine) {
             // Bottom Line
             [referenceFramePath moveToPoint:CGPointMake(0, self.frame.size.height)];
@@ -80,14 +82,14 @@
         }
     }
 
-    if (self.enableRefrenceLines == YES) {
-        if (self.arrayOfVerticalRefrenceLinePoints.count > 0) {
-            for (NSNumber *xNumber in self.arrayOfVerticalRefrenceLinePoints) {
+    if (self.enableReferenceLines == YES) {
+        if (self.arrayOfVerticalReferenceLinePoints.count > 0) {
+            for (NSNumber *xNumber in self.arrayOfVerticalReferenceLinePoints) {
                 CGFloat xValue;
                 if (self.verticalReferenceHorizontalFringeNegation != 0.0) {
-                    if ([self.arrayOfVerticalRefrenceLinePoints indexOfObject:xNumber] == 0) { // far left reference line
+                    if ([self.arrayOfVerticalReferenceLinePoints indexOfObject:xNumber] == 0) { // far left reference line
                         xValue = [xNumber floatValue] + self.verticalReferenceHorizontalFringeNegation;
-                    } else if ([self.arrayOfVerticalRefrenceLinePoints indexOfObject:xNumber] == [self.arrayOfVerticalRefrenceLinePoints count]-1) { // far right reference line
+                    } else if ([self.arrayOfVerticalReferenceLinePoints indexOfObject:xNumber] == [self.arrayOfVerticalReferenceLinePoints count]-1) { // far right reference line
                         xValue = [xNumber floatValue] - self.verticalReferenceHorizontalFringeNegation;
                     } else xValue = [xNumber floatValue];
                 } else xValue = [xNumber floatValue];
@@ -100,8 +102,8 @@
             }
         }
 
-        if (self.arrayOfHorizontalRefrenceLinePoints.count > 0) {
-            for (NSNumber *yNumber in self.arrayOfHorizontalRefrenceLinePoints) {
+        if (self.arrayOfHorizontalReferenceLinePoints.count > 0) {
+            for (NSNumber *yNumber in self.arrayOfHorizontalReferenceLinePoints) {
                 CGPoint initialPoint = CGPointMake(0, [yNumber floatValue]);
                 CGPoint finalPoint = CGPointMake(self.frame.size.width, [yNumber floatValue]);
 
@@ -139,16 +141,16 @@
     CGFloat xIndexScale = self.frame.size.width/([self.arrayOfPoints count] - 1);
 
     self.points = [NSMutableArray arrayWithCapacity:self.arrayOfPoints.count];
-    for (int i = 0; i < self.arrayOfPoints.count; i++) {
+    for (NSUInteger i = 0; i < self.arrayOfPoints.count; i++) {
         CGPoint value = CGPointMake(xIndexScale * i, [self.arrayOfPoints[i] CGFloatValue]);
-        if (value.y != BEMNullGraphValue || !self.interpolateNullValues) {
+        if (value.y < BEMNullGraphValue || !self.interpolateNullValues) {
             [self.points addObject:[NSValue valueWithCGPoint:value]];
         }
     }
 
     BOOL bezierStatus = self.bezierCurveIsEnabled;
     if (self.arrayOfPoints.count <= 2 && self.bezierCurveIsEnabled == YES) bezierStatus = NO;
-    
+
     if (!self.disableMainLine && bezierStatus) {
         line = [BEMLine quadCurvedPathWithPoints:self.points];
         fillBottom = [BEMLine quadCurvedPathWithPoints:self.bottomPointsArray];
@@ -192,20 +194,20 @@
     //----------------------------//
     //------ Animate Drawing -----//
     //----------------------------//
-    if (self.enableRefrenceLines == YES) {
+    if (self.enableReferenceLines == YES) {
         CAShapeLayer *verticalReferenceLinesPathLayer = [CAShapeLayer layer];
         verticalReferenceLinesPathLayer.frame = self.bounds;
         verticalReferenceLinesPathLayer.path = verticalReferenceLinesPath.CGPath;
-        verticalReferenceLinesPathLayer.opacity = self.lineAlpha == 0 ? 0.1 : self.lineAlpha/2;
+        verticalReferenceLinesPathLayer.opacity = (float)(self.lineAlpha <= 0 ? 0.1 : self.lineAlpha/2.0);
         verticalReferenceLinesPathLayer.fillColor = nil;
         verticalReferenceLinesPathLayer.lineWidth = self.referenceLineWidth/2;
-        
+
         if (self.lineDashPatternForReferenceYAxisLines) {
             verticalReferenceLinesPathLayer.lineDashPattern = self.lineDashPatternForReferenceYAxisLines;
         }
 
-        if (self.refrenceLineColor) {
-            verticalReferenceLinesPathLayer.strokeColor = self.refrenceLineColor.CGColor;
+        if (self.referenceLineColor) {
+            verticalReferenceLinesPathLayer.strokeColor = self.referenceLineColor.CGColor;
         } else {
             verticalReferenceLinesPathLayer.strokeColor = self.color.CGColor;
         }
@@ -218,15 +220,15 @@
         CAShapeLayer *horizontalReferenceLinesPathLayer = [CAShapeLayer layer];
         horizontalReferenceLinesPathLayer.frame = self.bounds;
         horizontalReferenceLinesPathLayer.path = horizontalReferenceLinesPath.CGPath;
-        horizontalReferenceLinesPathLayer.opacity = self.lineAlpha == 0 ? 0.1 : self.lineAlpha/2;
+        horizontalReferenceLinesPathLayer.opacity = (float)(self.lineAlpha <= 0 ? 0.1 : self.lineAlpha/2.0);
         horizontalReferenceLinesPathLayer.fillColor = nil;
         horizontalReferenceLinesPathLayer.lineWidth = self.referenceLineWidth/2;
         if(self.lineDashPatternForReferenceXAxisLines) {
             horizontalReferenceLinesPathLayer.lineDashPattern = self.lineDashPatternForReferenceXAxisLines;
         }
 
-        if (self.refrenceLineColor) {
-            horizontalReferenceLinesPathLayer.strokeColor = self.refrenceLineColor.CGColor;
+        if (self.referenceLineColor) {
+            horizontalReferenceLinesPathLayer.strokeColor = self.referenceLineColor.CGColor;
         } else {
             horizontalReferenceLinesPathLayer.strokeColor = self.color.CGColor;
         }
@@ -239,11 +241,11 @@
     CAShapeLayer *referenceLinesPathLayer = [CAShapeLayer layer];
     referenceLinesPathLayer.frame = self.bounds;
     referenceLinesPathLayer.path = referenceFramePath.CGPath;
-    referenceLinesPathLayer.opacity = self.lineAlpha == 0 ? 0.1 : self.lineAlpha/2;
+    referenceLinesPathLayer.opacity = (float)(self.lineAlpha <= 0 ? 0.1 : self.lineAlpha/2.0);
     referenceLinesPathLayer.fillColor = nil;
     referenceLinesPathLayer.lineWidth = self.referenceLineWidth/2;
 
-    if (self.refrenceLineColor) referenceLinesPathLayer.strokeColor = self.refrenceLineColor.CGColor;
+    if (self.referenceLineColor) referenceLinesPathLayer.strokeColor = self.referenceLineColor.CGColor;
     else referenceLinesPathLayer.strokeColor = self.color.CGColor;
 
     if (self.animationTime > 0)
@@ -256,7 +258,7 @@
         pathLayer.path = line.CGPath;
         pathLayer.strokeColor = self.color.CGColor;
         pathLayer.fillColor = nil;
-        pathLayer.opacity = self.lineAlpha;
+        pathLayer.opacity = (float)self.lineAlpha;
         pathLayer.lineWidth = self.lineWidth;
         pathLayer.lineJoin = kCALineJoinBevel;
         pathLayer.lineCap = kCALineCapRound;
@@ -269,7 +271,7 @@
         CAShapeLayer *averageLinePathLayer = [CAShapeLayer layer];
         averageLinePathLayer.frame = self.bounds;
         averageLinePathLayer.path = averageLinePath.CGPath;
-        averageLinePathLayer.opacity = self.averageLine.alpha;
+        averageLinePathLayer.opacity = (float)self.averageLine.alpha;
         averageLinePathLayer.fillColor = nil;
         averageLinePathLayer.lineWidth = self.averageLine.width;
 
@@ -349,7 +351,7 @@ static CGPoint midPointForPoints(CGPoint p1, CGPoint p2) {
 
 static CGPoint controlPointForPoints(CGPoint p1, CGPoint p2) {
     CGPoint controlPoint = midPointForPoints(p1, p2);
-    CGFloat diffY = fabs(p2.y - controlPoint.y);
+    CGFloat diffY = (CGFloat)fabs(p2.y - controlPoint.y);
 
     if (p1.y < p2.y)
         controlPoint.y += diffY;
@@ -365,8 +367,8 @@ static CGPoint controlPointForPoints(CGPoint p1, CGPoint p2) {
         CABasicAnimation *pathAnimation = [CABasicAnimation animationWithKeyPath:@"opacity"];
         pathAnimation.duration = self.animationTime;
         pathAnimation.fromValue = [NSNumber numberWithFloat:0.0f];
-        if (shouldHalfOpacity == YES) pathAnimation.toValue = [NSNumber numberWithFloat:self.lineAlpha == 0 ? 0.1 : self.lineAlpha/2];
-        else pathAnimation.toValue = [NSNumber numberWithFloat:self.lineAlpha];
+        if (shouldHalfOpacity == YES) pathAnimation.toValue = [NSNumber numberWithDouble:self.lineAlpha <= 0 ? 0.1f : self.lineAlpha/2.0f];
+        else pathAnimation.toValue = [NSNumber numberWithDouble:self.lineAlpha];
         [shapeLayer addAnimation:pathAnimation forKey:@"opacity"];
 
         return;
@@ -374,7 +376,7 @@ static CGPoint controlPointForPoints(CGPoint p1, CGPoint p2) {
         CABasicAnimation *pathAnimation = [CABasicAnimation animationWithKeyPath:@"lineWidth"];
         pathAnimation.duration = self.animationTime;
         pathAnimation.fromValue = [NSNumber numberWithFloat:0.0f];
-        pathAnimation.toValue = [NSNumber numberWithFloat:shapeLayer.lineWidth];
+        pathAnimation.toValue = [NSNumber numberWithDouble:shapeLayer.lineWidth];
         [shapeLayer addAnimation:pathAnimation forKey:@"lineWidth"];
 
         return;

--- a/Classes/BEMSimpleLineGraphView.h
+++ b/Classes/BEMSimpleLineGraphView.h
@@ -37,7 +37,7 @@ IB_DESIGNABLE @interface BEMSimpleLineGraphView : UIView <UIGestureRecognizerDel
 
 
 /** The object that acts as the delegate of the receiving line graph.
- 
+
  @abstract The BEMSimpleLineGraphView delegate object plays a key role in changing the appearance of the graph and receiving graph events. Use the delegate to provide appearance changes, receive touch events, and receive graph events. The delegate can be set from the interface or from code.
  @discussion The delegate must adopt the \p BEMSimpleLineGraphDelegate protocol. The delegate is not retained.*/
 @property (nonatomic, weak, nullable) IBOutlet id <BEMSimpleLineGraphDelegate> delegate;
@@ -50,7 +50,7 @@ IB_DESIGNABLE @interface BEMSimpleLineGraphView : UIView <UIGestureRecognizerDel
 
 
 /** The object that acts as the data source of the receiving line graph.
- 
+
  @abstract The BEMSimpleLineGraphView data source object is essential to the line graph. Use the data source to provide the graph with data (data points and x-axis labels). The delegate can be set from the interface or from code.
  @discussion The data source must adopt the \p BEMSimpleLineGraphDataSource protocol. The data source is not retained.*/
 @property (nonatomic, weak) IBOutlet id <BEMSimpleLineGraphDataSource> dataSource;
@@ -114,18 +114,22 @@ IB_DESIGNABLE @interface BEMSimpleLineGraphView : UIView <UIGestureRecognizerDel
 
 /** All the displayed values of the X-Axis.
  @return An array of NSStrings, one for each displayed X-Axis label. The array is sorted from the left side of the graph to the right side. */
-- (nullable NSArray *)graphValuesForXAxis;
+- (nullable NSArray <NSString *> *)graphValuesForXAxis;
 
 
 /** All the data points on the graph.
  @return An array of NSNumbers, one for each data point. The array is sorted from the left side of the graph to the right side. */
-- (nullable NSArray *)graphValuesForDataPoints;
+- (nullable NSArray <NSNumber *> *)graphValuesForDataPoints;
 
 
 /** All the labels of the X-Axis.
  @return An array of UILabels, one for each displayed X-Axis label. The array is sorted from the left side of the graph to the right side. */
-- (nullable NSArray *)graphLabelsForXAxis;
+- (nullable NSArray <UILabel *> *)graphLabelsForXAxis;
 
+
+/** All the labels of the Y-Axis.
+ @return An array of UILabels, one for each displayed Y-Axis label. The array is sorted from the bottom side of the graph to the top side. */
+- (nullable NSArray <UILabel *> *)graphLabelsForYAxis;
 
 
 //------------------------------------------------------------------------------------//
@@ -152,7 +156,7 @@ IB_DESIGNABLE @interface BEMSimpleLineGraphView : UIView <UIGestureRecognizerDel
 
 /** The number of fingers required to report touches to the graph's delegate. The default value is 1.
  @discussion Setting this value to greater than 1 might be beneficial in interfaces that allow the graph to scroll and still want to use touch reporting. */
-@property (nonatomic) NSInteger touchReportFingersRequired;
+@property (nonatomic) NSUInteger touchReportFingersRequired;
 
 
 /// If set to YES, a label will pop up on the graph when the user touches it. It will be displayed on top of the closest point from the user current touch location. Default value is NO.
@@ -164,13 +168,13 @@ IB_DESIGNABLE @interface BEMSimpleLineGraphView : UIView <UIGestureRecognizerDel
 
 
 /** Show Y-Axis label on the side. Default value is NO.
- @todo Could enhance further by specifying the position of Y-Axis, i.e. Left or Right of the view.  Also auto detection on label overlapping. */
+ */
 @property (nonatomic) IBInspectable BOOL enableYAxisLabel;
 
 
 /** Show X-Axis label at the bottom of the graph. Default value is YES.
  @see \p labelOnXAxisForIndex */
- @property (nonatomic) IBInspectable BOOL enableXAxisLabel;
+@property (nonatomic) IBInspectable BOOL enableXAxisLabel;
 
 
 /** When set to YES, the points on the Y-axis will be set to all fit in the graph view. When set to NO, the points on the Y-axis will be set with their absolute value (which means that certain points might not be visible because they are outside of the view). Default value is YES. */
@@ -230,7 +234,7 @@ IB_DESIGNABLE @interface BEMSimpleLineGraphView : UIView <UIGestureRecognizerDel
 
 
 /// Fill gradient of the bottom part of the graph (between the line and the X-axis). When set, it will draw a gradient over top of the fill provided by the \p colorBottom and \p alphaBottom properties.
-@property (assign, nonatomic) CGGradientRef gradientBottom;
+@property (assign, nonatomic, nullable) CGGradientRef gradientBottom;
 
 
 /// Color of the top part of the graph (between the line and the top of the view the graph is drawn in).
@@ -242,7 +246,7 @@ IB_DESIGNABLE @interface BEMSimpleLineGraphView : UIView <UIGestureRecognizerDel
 
 
 /// Fill gradient of the top part of the graph (between the line and the top of the view the graph is drawn in). When set, it will draw a gradient over top of the fill provided by the \p colorTop and \p alphaTop properties.
-@property (assign, nonatomic) CGGradientRef gradientTop;
+@property (assign, nonatomic, nullable) CGGradientRef gradientTop;
 
 
 /// Color of the line of the graph.
@@ -298,19 +302,19 @@ IB_DESIGNABLE @interface BEMSimpleLineGraphView : UIView <UIGestureRecognizerDel
 
 
 /// Color of the background of the X-Axis
-@property (strong, nonatomic) UIColor *colorBackgroundXaxis;
+@property (strong, nonatomic) IBInspectable UIColor *colorBackgroundXaxis;
 
 
 /// Alpha of the background of the X-Axis
-@property (nonatomic) CGFloat alphaBackgroundXaxis;
+@property (nonatomic) IBInspectable CGFloat alphaBackgroundXaxis;
 
 
 /// Color of the background of the Y-Axis
-@property (strong, nonatomic) UIColor *colorBackgroundYaxis;
+@property (strong, nonatomic) IBInspectable UIColor *colorBackgroundYaxis;
 
 
 /// Alpha of the background of the Y-Axis
-@property (nonatomic) CGFloat alphaBackgroundYaxis;
+@property (nonatomic) IBInspectable CGFloat alphaBackgroundYaxis;
 
 
 /// Color of the label's text displayed on the Y-Axis. Defaut value is blackColor.
@@ -322,7 +326,7 @@ IB_DESIGNABLE @interface BEMSimpleLineGraphView : UIView <UIGestureRecognizerDel
 
 
 /// Position of the y-Axis in relation to the chart (Default: NO)
-@property (nonatomic) BOOL positionYAxisRight;
+@property (nonatomic) IBInspectable BOOL positionYAxisRight;
 
 
 /// A line dash patter to be applied to X axis reference lines.  This allows you to draw a dotted or hashed line
@@ -350,7 +354,7 @@ IB_DESIGNABLE @interface BEMSimpleLineGraphView : UIView <UIGestureRecognizerDel
 
 
 /// When set to YES, dots will be displayed at full opacity and no line will be drawn through the dots. Default value is NO.
-@property (nonatomic) BOOL displayDotsOnly;
+@property (nonatomic) IBInspectable BOOL displayDotsOnly;
 
 
 @end
@@ -377,14 +381,14 @@ IB_DESIGNABLE @interface BEMSimpleLineGraphView : UIView <UIGestureRecognizerDel
 /** The number of points along the X-axis of the graph.
  @param graph The graph object requesting the total number of points.
  @return The total number of points in the line graph. */
-- (NSInteger)numberOfPointsInLineGraph:(BEMSimpleLineGraphView *)graph;
+- (NSUInteger)numberOfPointsInLineGraph:(BEMSimpleLineGraphView *)graph;
 
 
 /** The vertical position for a point at the given index. It corresponds to the Y-axis value of the Graph.
  @param graph The graph object requesting the point value.
  @param index The index from left to right of a given point (X-axis). The first value for the index is 0.
  @return The Y-axis value at a given index. */
-- (CGFloat)lineGraph:(BEMSimpleLineGraphView *)graph valueForPointAtIndex:(NSInteger)index;
+- (CGFloat)lineGraph:(BEMSimpleLineGraphView *)graph valueForPointAtIndex:(NSUInteger)index;
 
 
 @optional
@@ -396,7 +400,7 @@ IB_DESIGNABLE @interface BEMSimpleLineGraphView : UIView <UIGestureRecognizerDel
  @discussion The number of strings to be returned should be equal to the number of points in the graph (returned in \p numberOfPointsInLineGraph). Otherwise, an exception may be thrown.
  @param graph The graph object which is requesting the label on the specified X-Axis position.
  @param index The index from left to right of a given label on the X-axis. Is the same index as the one for the points. The first value for the index is 0. */
-- (nullable NSString *)lineGraph:(nonnull BEMSimpleLineGraphView *)graph labelOnXAxisForIndex:(NSInteger)index;
+- (nullable NSString *)lineGraph:(nonnull BEMSimpleLineGraphView *)graph labelOnXAxisForIndex:(NSUInteger)index;
 
 
 @end
@@ -422,7 +426,7 @@ IB_DESIGNABLE @interface BEMSimpleLineGraphView : UIView <UIGestureRecognizerDel
 
 /** Sent to the delegate each time the line graph finishes loading or reloading.
  @discussion The respective graph object's data has been loaded at this time. However, the graph may not be fully rendered. Use this method to update any content with the new graph object's data.
- 
+
  @seealso lineGraphDidBeginLoading: lineGraphDidFinishDrawing:
  @param graph The graph object that finished loading or reloading. */
 - (void)lineGraphDidFinishLoading:(BEMSimpleLineGraphView *)graph;
@@ -430,9 +434,9 @@ IB_DESIGNABLE @interface BEMSimpleLineGraphView : UIView <UIGestureRecognizerDel
 
 /** Sent to the delegate each time the line graph finishes animating and drawing.
  @discussion The respective graph object has been completely drawn and animated at this point. It is safe to use \p graphSnapshotImage after recieving this method call on the delegate.
- 
+
  This method may be called in addition to the \p lineGraphDidFinishLoading: method, after drawing has completed. \p animationGraphEntranceTime is taken into account when calling this method.
- 
+
  @seealso lineGraphDidFinishLoading:
  @param graph The graph object that finished drawing. */
 - (void)lineGraphDidFinishDrawing:(BEMSimpleLineGraphView *)graph;
@@ -440,15 +444,20 @@ IB_DESIGNABLE @interface BEMSimpleLineGraphView : UIView <UIGestureRecognizerDel
 
 //----- CUSTOMIZATION -----//
 
+/** The optional text for the popup report. Replaces
+ @param graph The graph object requesting the total number of points.
+ @return The suffix to append to the popup report. */
+- (NSString *)popUpTextForlineGraph:(BEMSimpleLineGraphView *)graph atIndex: (NSUInteger) index;
+
 
 /** The optional suffix to append to the popup report.
- @param graph The graph object requesting the total number of points.
+ @param graph The graph object requesting the suffix.
  @return The suffix to append to the popup report. */
 - (NSString *)popUpSuffixForlineGraph:(BEMSimpleLineGraphView *)graph;
 
 
 /** The optional prefix to append to the popup report.
- @param graph The graph object requesting the total number of points.
+ @param graph The graph object requesting the prefix.
  @return The prefix to prepend to the popup report. */
 - (NSString *)popUpPrefixForlineGraph:(BEMSimpleLineGraphView *)graph;
 
@@ -500,8 +509,7 @@ IB_DESIGNABLE @interface BEMSimpleLineGraphView : UIView <UIGestureRecognizerDel
 /** Optional method that gets called if you are using a custom popup view.  This method allows you to modify your popup view for different graph indices
  @param graph The graph object requesting the padding value.
  @param popupView The popup view owned by the graph that needs to be modified
- @param index The index of the element associated with the popup view
- @return The custom popup view to use */
+ @param index The index of the element associated with the popup view */
 - (void)lineGraph:(BEMSimpleLineGraphView *)graph modifyPopupView:(UIView *)popupView forIndex:(NSUInteger)index;
 
 
@@ -511,7 +519,7 @@ IB_DESIGNABLE @interface BEMSimpleLineGraphView : UIView <UIGestureRecognizerDel
 /** Sent to the delegate when the user starts touching the graph. The property 'enableTouchReport' must be set to YES.
  @param graph The graph object which was touched by the user.
  @param index The closest index (X-axis) from the location the user is currently touching. */
-- (void)lineGraph:(BEMSimpleLineGraphView *)graph didTouchGraphWithClosestIndex:(NSInteger)index;
+- (void)lineGraph:(BEMSimpleLineGraphView *)graph didTouchGraphWithClosestIndex:(NSUInteger)index;
 
 
 /** Sent to the delegate when the user stops touching the graph.
@@ -527,27 +535,27 @@ IB_DESIGNABLE @interface BEMSimpleLineGraphView : UIView <UIGestureRecognizerDel
  @discussion For example returning '1' would mean that half of the labels on the X-axis are not displayed: the first is not displayed, the second is, the third is not etc. Returning '0' would mean that all of the labels will be displayed. Finally, returning a value equal to the number of labels will only display the first and last label.
  @param graph The graph object which is requesting the number of gaps between the labels.
  @return The number of labels to "jump" between each displayed label on the X-axis. */
-- (NSInteger)numberOfGapsBetweenLabelsOnLineGraph:(BEMSimpleLineGraphView *)graph;
+- (NSUInteger)numberOfGapsBetweenLabelsOnLineGraph:(BEMSimpleLineGraphView *)graph;
 
 
 /** The starting index to plot X-Axis values.  MUST ALSO IMPLEMENT incrementIndexForXAxisOnLineGraph FOR THIS TO TAKE EFFECT
  @discussion This allows you to specify a custom starting index for drawing x axis labels
  @param graph The graph object which is requesting the number of gaps between the labels.
  @return The graph data index to begin drawing labels */
-- (NSInteger)baseIndexForXAxisOnLineGraph:(BEMSimpleLineGraphView *)graph;
+- (NSUInteger)baseIndexForXAxisOnLineGraph:(BEMSimpleLineGraphView *)graph;
 
 
 /** The increment to apply when drawing X-Axis labels.  This increment is applied to the base x axis index.  MUST ALSO IMPLEMENT baseIndexForXAxisOnLineGraph FOR THIS TO TAKE EFFECT
  @discussion This allows you to set a custom interval in drawing x axis labels. When this is set in conjuction with baseIndexForXAxisOnLineGraph, `numberOfGapsBetweenLabelsOnLineGraph` is ignored
  @param graph The graph object which is requesting the number of gaps between the labels.
  @return The increment between X-Axis labels */
-- (NSInteger)incrementIndexForXAxisOnLineGraph:(BEMSimpleLineGraphView *)graph;
+- (NSUInteger)incrementIndexForXAxisOnLineGraph:(BEMSimpleLineGraphView *)graph;
 
 
 /** An array of graph indices where X-Axis labels should be drawn
  @discussion This allows high customization over where X-Axis labels can be placed.  They can be placed in non-consistent intervals. Additionally,
-    it allows you to draw the X-Axis labels based on traits of your data (eg. when the date corresponding to the data becomes a new day). 
-    When this is set, `numberOfGapsBetweenLabelsOnLineGraph` is ignored
+ it allows you to draw the X-Axis labels based on traits of your data (eg. when the date corresponding to the data becomes a new day).
+ When this is set, `numberOfGapsBetweenLabelsOnLineGraph` is ignored
  @param graph The graph object which is requesting the number of gaps between the labels.
  @return Array of graph indices to place X-Axis labels */
 - (NSArray *)incrementPositionsForXAxisOnLineGraph:(BEMSimpleLineGraphView *)graph;
@@ -561,7 +569,7 @@ IB_DESIGNABLE @interface BEMSimpleLineGraphView : UIView <UIGestureRecognizerDel
  @discussion Calculates the total height of the graph and evenly spaces the labels based on the graph height. Default value is 3.
  @param graph The graph object which is requesting the number of labels.
  @return The number of labels displayed on the Y-axis. */
-- (NSInteger)numberOfYAxisLabelsOnLineGraph:(BEMSimpleLineGraphView *)graph;
+- (NSUInteger)numberOfYAxisLabelsOnLineGraph:(BEMSimpleLineGraphView *)graph;
 
 
 /** The optional prefix to append to the y axis.
@@ -577,8 +585,8 @@ IB_DESIGNABLE @interface BEMSimpleLineGraphView : UIView <UIGestureRecognizerDel
 
 
 /** Starting value to begin drawing Y-Axis labels  MUST ALSO IMPLEMENT incrementValueForYAxisOnLineGraph FOR THIS TO TAKE EFFECT
- @discussion This allows you to finally hone the granularity of the data label.  Instead of drawing values like 11.24, 
-    you can lock these values to draw 11.20 to make it more user friendly.  When this is set, `numberOfYAxisLabelsOnLineGraph` is ignored.
+ @discussion This allows you to finally hone the granularity of the data label.  Instead of drawing values like 11.24,
+ you can lock these values to draw 11.20 to make it more user friendly.  When this is set, `numberOfYAxisLabelsOnLineGraph` is ignored.
  @param graph The graph object which is requesting the number of gaps between the labels.
  @return The base value to draw the first Y-Axis label */
 - (CGFloat)baseValueForYAxisOnLineGraph:(BEMSimpleLineGraphView *)graph;
@@ -586,7 +594,7 @@ IB_DESIGNABLE @interface BEMSimpleLineGraphView : UIView <UIGestureRecognizerDel
 
 /** Increment value to apply to the base Y-Axis label.  MUST ALSO IMPLEMENT baseValueForYAxisOnLineGraph FOR THIS TO TAKE EFFECT
  @discussion This value tells the graph the interval to be applied to the base Y-Axis value.  This allows you to increment the Y-Axis via user-friendly values rather than values
-    like 37.17.  This let's you enforce that your Y-Axis have values rounded to whatever granularity best fits your data.
+ like 37.17.  This let's you enforce that your Y-Axis have values rounded to whatever granularity best fits your data.
  @param graph The graph object which is requesting the number of gaps between the labels.
  @return The increment value to add to the value returned from `baseValueForYAxisOnLineGraph` for future Y-Axis labels */
 - (CGFloat)incrementValueForYAxisOnLineGraph:(BEMSimpleLineGraphView *)graph;

--- a/Classes/BEMSimpleLineGraphView.m
+++ b/Classes/BEMSimpleLineGraphView.m
@@ -8,6 +8,7 @@
 //
 
 #import "BEMSimpleLineGraphView.h"
+#import "tgmath.h"
 
 const CGFloat BEMNullGraphValue = CGFLOAT_MAX;
 
@@ -17,49 +18,56 @@ const CGFloat BEMNullGraphValue = CGFLOAT_MAX;
 #error BEMSimpleLineGraph is built with Objective-C ARC. You must enable ARC for these files.
 #endif
 
-#define SYSTEM_VERSION_GREATER_THAN_OR_EQUAL_TO(v)  ([[[UIDevice currentDevice] systemVersion] compare:v options:NSNumericSearch] != NSOrderedAscending)
-#define DEFAULT_FONT_NAME @"HelveticaNeue-Light"
-
-
 typedef NS_ENUM(NSInteger, BEMInternalTags)
 {
     DotFirstTag100 = 100,
-    DotLastTag1000 = 1000,
-    LabelYAxisTag2000 = 2000,
-    BackgroundYAxisTag2100 = 2100,
-    BackgroundXAxisTag2200 = 2200,
-    PermanentPopUpViewTag3100 = 3100,
 };
 
 @interface BEMSimpleLineGraphView () {
     /// The number of Points in the Graph
-    NSInteger numberOfPoints;
-    
-    /// The closest point to the touch point
-    BEMCircle *closestDot;
-    CGFloat currentlyCloser;
-    
+    NSUInteger numberOfPoints;
+
     /// All of the X-Axis Values
-    NSMutableArray *xAxisValues;
-    
+    NSMutableArray <NSString *>*xAxisValues;
+
     /// All of the X-Axis Label Points
-    NSMutableArray *xAxisLabelPoints;
-    
-    /// All of the X-Axis Label Points
+    NSMutableArray <NSNumber *>*xAxisLabelPoints;
+
+    /// How much to ??
     CGFloat xAxisHorizontalFringeNegationValue;
-    
+
     /// All of the Y-Axis Label Points
-    NSMutableArray *yAxisLabelPoints;
-    
+    NSMutableArray <NSNumber *> *yAxisLabelPoints;
+
     /// All of the Y-Axis Values
-    NSMutableArray *yAxisValues;
-    
+    NSMutableArray <NSNumber *>*yAxisValues;
+
     /// All of the Data Points
-    NSMutableArray *dataPoints;
-    
-    /// All of the X-Axis Labels
-    NSMutableArray *xAxisLabels;
+    NSMutableArray <NSNumber *> *dataPoints;
+
 }
+
+#pragma mark Properties to store all subviews
+// Stores the background X Axis view
+@property (strong, nonatomic ) UIView *backgroundXAxis;
+
+// Stores the background Y Axis view
+@property (strong, nonatomic) UIView *backgroundYAxis;
+
+/// All of the Y-Axis Labels
+@property (strong, nonatomic) NSMutableArray <UILabel *> *yAxisLabels;
+
+/// All of the X-Axis Labels
+@property (strong, nonatomic) NSMutableArray <UILabel *> *xAxisLabels;
+
+/// All of the dataPoint Labels
+@property (strong, nonatomic) NSMutableArray <BEMPermanentPopupLabel *> *permanentPopups;
+
+/// All of the dataPoint dots
+@property (strong, nonatomic) NSMutableArray <BEMCircle *> *circleDots;
+
+/// The line itself
+@property (strong, nonatomic) BEMLine * masterLine;
 
 /// The vertical line which appears when the user drags across the graph
 @property (strong, nonatomic) UIView *touchInputLine;
@@ -70,6 +78,9 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
 /// Label to display when there is no data
 @property (strong, nonatomic) UILabel *noDataLabel;
 
+/// Cirle to display when there's only one datapoint
+@property (strong, nonatomic) BEMCircle *oneDot;
+
 /// The gesture recognizer picking up the pan in the graph view
 @property (strong, nonatomic) UIPanGestureRecognizer *panGesture;
 
@@ -77,17 +88,10 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
 @property (nonatomic) UILongPressGestureRecognizer *longPressGesture;
 
 /// The label displayed when enablePopUpReport is set to YES
-@property (strong, nonatomic) UILabel *popUpLabel;
+@property (strong, nonatomic) BEMPermanentPopupLabel *popUpLabel;
 
-/// The view used for the background of the popup label
-@property (strong, nonatomic) UIView *popUpView;
 
-/// The X position (center) of the view for the popup label
-@property (nonatomic) CGFloat xCenterLabel;
-
-/// The Y position (center) of the view for the popup label
-@property (nonatomic) CGFloat yCenterLabel;
-
+#pragma mark calculated properties
 /// The Y offset necessary to compensate the labels on the X-Axis
 @property (nonatomic) CGFloat XAxisLabelYOffset;
 
@@ -100,6 +104,12 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
 /// The smallest value out of all of the data points
 @property (nonatomic) CGFloat minValue;
 
+// Tracks whether the popUpView is custom or default
+@property (nonatomic) BOOL usingCustomPopupView;
+
+// Stores the current view size to detect whether a redraw is needed in layoutSubviews
+@property (nonatomic) CGSize currentViewSize;
+
 /// Find which point is currently the closest to the vertical line
 - (BEMCircle *)closestDotFromtouchInputLine:(UIView *)touchInputLine;
 
@@ -109,14 +119,6 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
 /// Determines the smallest Y-axis value from all the points
 - (CGFloat)minValue;
 
-// Tracks whether the popUpView is custom or default
-@property (nonatomic) BOOL usingCustomPopupView;
-
-// Stores the current view size to detect whether a redraw is needed in layoutSubviews
-@property (nonatomic) CGSize currentViewSize;
-
-// Stores the background X Axis view
-@property (nonatomic) UIView *backgroundXAxis;
 
 @end
 
@@ -138,40 +140,40 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
 
 - (void)commonInit {
     // Do any initialization that's common to both -initWithFrame: and -initWithCoder: in this method
-    
+
     // Set the X Axis label font
-    _labelFont = [UIFont fontWithName:DEFAULT_FONT_NAME size:13];
-    
+    _labelFont = [UIFont preferredFontForTextStyle:UIFontTextStyleCaption1];
+
     // Set Animation Values
     _animationGraphEntranceTime = 1.5;
-    
+
     // Set Color Values
     _colorXaxisLabel = [UIColor blackColor];
     _colorYaxisLabel = [UIColor blackColor];
-    _colorTop = [UIColor colorWithRed:0 green:122.0/255.0 blue:255/255 alpha:1];
-    _colorLine = [UIColor colorWithRed:255.0/255.0 green:255.0/255.0 blue:255.0/255.0 alpha:1];
-    _colorBottom = [UIColor colorWithRed:0 green:122.0/255.0 blue:255/255 alpha:1];
-    _colorPoint = [UIColor colorWithWhite:1.0 alpha:0.7];
+    _colorTop = [UIColor colorWithRed:0 green:122.0f/255.0f blue:255.0f/255.0f alpha:1.0f];
+    _colorLine = [UIColor colorWithRed:255.0f/255.0f green:255.0f/255.0f blue:255.0f/255.0f alpha:1.0f];
+    _colorBottom = [UIColor colorWithRed:0 green:122.0f/255.0f blue:255.0f/255.0f alpha:1];
+    _colorPoint = [UIColor colorWithWhite:1.0f alpha:0.7f];
     _colorTouchInputLine = [UIColor grayColor];
     _colorBackgroundPopUplabel = [UIColor whiteColor];
-    _alphaTouchInputLine = 0.2;
+    _alphaTouchInputLine = 0.2f;
     _widthTouchInputLine = 1.0;
     _colorBackgroundXaxis = nil;
     _alphaBackgroundXaxis = 1.0;
     _colorBackgroundYaxis = nil;
     _alphaBackgroundYaxis = 1.0;
     _displayDotsWhileAnimating = YES;
-    
+
     // Set Alpha Values
     _alphaTop = 1.0;
     _alphaBottom = 1.0;
     _alphaLine = 1.0;
-    
+
     // Set Size Values
     _widthLine = 1.0;
     _widthReferenceLines = 1.0;
     _sizePoint = 10.0;
-    
+
     // Set Default Feature Values
     _enableTouchReport = NO;
     _touchReportFingersRequired = 1;
@@ -188,15 +190,19 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
     _formatStringForValues = @"%.0f";
     _interpolateNullValues = YES;
     _displayDotsOnly = NO;
-    
+
     // Initialize the various arrays
     xAxisValues = [NSMutableArray array];
-    xAxisHorizontalFringeNegationValue = 0.0;
     xAxisLabelPoints = [NSMutableArray array];
+    yAxisValues = [NSMutableArray array];
     yAxisLabelPoints = [NSMutableArray array];
     dataPoints = [NSMutableArray array];
-    xAxisLabels = [NSMutableArray array];
-    yAxisValues = [NSMutableArray array];
+    _xAxisLabels = [NSMutableArray array];
+    _yAxisLabels = [NSMutableArray array];
+    _permanentPopups = [NSMutableArray array];
+    _circleDots = [NSMutableArray array];
+    xAxisHorizontalFringeNegationValue = 0.0;
+
 
     // Initialize BEM Objects
     _averageLine = [[BEMAverageLine alloc] init];
@@ -209,7 +215,7 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
         if ([subview isEqual:self.noDataLabel])
             [subview removeFromSuperview];
     }
-    
+
     [self drawEntireGraph];
 }
 
@@ -217,19 +223,19 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
     // Let the delegate know that the graph began layout updates
     if ([self.delegate respondsToSelector:@selector(lineGraphDidBeginLoading:)])
         [self.delegate lineGraphDidBeginLoading:self];
-    
+
     // Get the number of points in the graph
     [self layoutNumberOfPoints];
-    
+
     if (numberOfPoints <= 1) {
         return;
     } else {
         // Draw the graph
         [self drawEntireGraph];
-        
+
         // Setup the touch report
         [self layoutTouchReport];
-        
+
         // Let the delegate know that the graph finished updates
         if ([self.delegate respondsToSelector:@selector(lineGraphDidFinishLoading:)])
             [self.delegate lineGraphDidFinishLoading:self];
@@ -239,7 +245,7 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
 
 - (void)layoutSubviews {
     [super layoutSubviews];
-    
+
     if (CGSizeEqualToSize(self.currentViewSize, self.bounds.size))  return;
     self.currentViewSize = self.bounds.size;
 
@@ -250,9 +256,9 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
     // Get the total number of data points from the delegate
     if ([self.dataSource respondsToSelector:@selector(numberOfPointsInLineGraph:)]) {
         numberOfPoints = [self.dataSource numberOfPointsInLineGraph:self];
-        
+
     } else numberOfPoints = 0;
-    
+
     // There are no points to load
     if (numberOfPoints == 0) {
         if (self.delegate &&
@@ -260,17 +266,17 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
             ![self.delegate noDataLabelEnableForLineGraph:self]) return;
 
         NSLog(@"[BEMSimpleLineGraph] Data source contains no data. A no data label will be displayed and drawing will stop. Add data to the data source and then reload the graph.");
-        
-#if !TARGET_INTERFACE_BUILDER
+
+#ifndef TARGET_INTERFACE_BUILDER
         self.noDataLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, self.viewForBaselineLayout.frame.size.width, self.viewForBaselineLayout.frame.size.height)];
 #else
         self.noDataLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, self.viewForBaselineLayout.frame.size.width, self.viewForBaselineLayout.frame.size.height-(self.viewForBaselineLayout.frame.size.height/4))];
 #endif
-        
+
         self.noDataLabel.backgroundColor = [UIColor clearColor];
         self.noDataLabel.textAlignment = NSTextAlignmentCenter;
 
-#if !TARGET_INTERFACE_BUILDER
+#ifndef TARGET_INTERFACE_BUILDER
         NSString *noDataText;
         if ([self.delegate respondsToSelector:@selector(noDataLabelTextForLineGraph:)]) {
             noDataText = [self.delegate noDataLabelTextForLineGraph:self];
@@ -283,12 +289,11 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
         self.noDataLabel.textColor = self.noDataLabelColor ?: self.colorLine;
 
         [self.viewForBaselineLayout addSubview:self.noDataLabel];
-        
+
         // Let the delegate know that the graph finished layout updates
         if ([self.delegate respondsToSelector:@selector(lineGraphDidFinishLoading:)])
             [self.delegate lineGraphDidFinishLoading:self];
-        return;
-        
+
     } else if (numberOfPoints == 1) {
         NSLog(@"[BEMSimpleLineGraph] Data source contains only one data point. Add more data to the data source and then reload the graph.");
         BEMCircle *circleDot = [[BEMCircle alloc] initWithFrame:CGRectMake(0, 0, self.sizePoint, self.sizePoint)];
@@ -296,14 +301,12 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
         circleDot.color = self.colorPoint;
         circleDot.alpha = 1;
         [self addSubview:circleDot];
-        return;
-        
+        self.oneDot = circleDot;
+
     } else {
-        // Remove all dots that were previously on the graph
-        for (UILabel *subview in [self subviews]) {
-            if ([subview isEqual:self.noDataLabel])
-                [subview removeFromSuperview];
-        }
+        // Remove all dots that might have previously been on the graph
+        [self.noDataLabel removeFromSuperview];
+        [self.oneDot  removeFromSuperview];
     }
 }
 
@@ -311,70 +314,26 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
     // If the touch report is enabled, set it up
     if (self.enableTouchReport == YES || self.enablePopUpReport == YES) {
         // Initialize the vertical gray line that appears where the user touches the graph.
-        self.touchInputLine = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.widthTouchInputLine, self.frame.size.height)];
-        self.touchInputLine.backgroundColor = self.colorTouchInputLine;
-        self.touchInputLine.alpha = 0;
-        [self addSubview:self.touchInputLine];
-        
-        self.panView = [[UIView alloc] initWithFrame:CGRectMake(10, 10, self.viewForBaselineLayout.frame.size.width, self.viewForBaselineLayout.frame.size.height)];
-        self.panView.backgroundColor = [UIColor clearColor];
-        [self.viewForBaselineLayout addSubview:self.panView];
-        
-        self.panGesture = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handleGestureAction:)];
-        self.panGesture.delegate = self;
-        [self.panGesture setMaximumNumberOfTouches:1];
-        [self.panView addGestureRecognizer:self.panGesture];
-        
-        self.longPressGesture = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleGestureAction:)];
-        self.longPressGesture.minimumPressDuration = 0.1f;
-        [self.panView addGestureRecognizer:self.longPressGesture];
-        
-        if (self.enablePopUpReport == YES && self.alwaysDisplayPopUpLabels == NO) {
-            if ([self.delegate respondsToSelector:@selector(popUpViewForLineGraph:)]) {
-                self.popUpView = [self.delegate popUpViewForLineGraph:self];
-                self.usingCustomPopupView = YES;
-                self.popUpView.alpha = 0;
-                [self addSubview:self.popUpView];
-            } else {
-                NSString *maxValueString = [NSString stringWithFormat:self.formatStringForValues, [self calculateMaximumPointValue].doubleValue];
-                NSString *minValueString = [NSString stringWithFormat:self.formatStringForValues, [self calculateMinimumPointValue].doubleValue];
-                
-                NSString *longestString = @"";
-                if (maxValueString.length > minValueString.length) {
-                    longestString = maxValueString;
-                } else {
-                    longestString = minValueString;
-                }
-                
-                NSString *prefix = @"";
-                NSString *suffix = @"";
-                if ([self.delegate respondsToSelector:@selector(popUpSuffixForlineGraph:)]) {
-                    suffix = [self.delegate popUpSuffixForlineGraph:self];
-                }
-                if ([self.delegate respondsToSelector:@selector(popUpPrefixForlineGraph:)]) {
-                    prefix = [self.delegate popUpPrefixForlineGraph:self];
-                }
-                
-                NSString *fullString = [NSString stringWithFormat:@"%@%@%@", prefix, longestString, suffix];
-                
-                NSString *mString = [fullString stringByReplacingOccurrencesOfString:@"[0-9-]" withString:@"N" options:NSRegularExpressionSearch range:NSMakeRange(0, [longestString length])];
-                
-                self.popUpLabel = [[UILabel alloc] initWithFrame:CGRectMake(0, 0, 200, 20)];
-                self.popUpLabel.text = mString;
-                self.popUpLabel.textAlignment = 1;
-                self.popUpLabel.numberOfLines = 1;
-                self.popUpLabel.font = self.labelFont;
-                self.popUpLabel.backgroundColor = [UIColor clearColor];
-                [self.popUpLabel sizeToFit];
-                self.popUpLabel.alpha = 0;
-                
-                self.popUpView = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.popUpLabel.frame.size.width + 10, self.popUpLabel.frame.size.height + 2)];
-                self.popUpView.backgroundColor = self.colorBackgroundPopUplabel;
-                self.popUpView.alpha = 0;
-                self.popUpView.layer.cornerRadius = 3;
-                [self addSubview:self.popUpView];
-                [self addSubview:self.popUpLabel];
-            }
+        if (!self.touchInputLine) {
+            self.touchInputLine = [[UIView alloc] initWithFrame:CGRectMake(0, 0, self.widthTouchInputLine, self.frame.size.height)];
+            self.touchInputLine.backgroundColor = self.colorTouchInputLine;
+            self.touchInputLine.alpha = 0;
+            [self addSubview:self.touchInputLine];
+        }
+
+        if (!self.panView) {
+            self.panView = [[UIView alloc] initWithFrame:CGRectMake(10, 10, self.viewForBaselineLayout.frame.size.width, self.viewForBaselineLayout.frame.size.height)];
+            self.panView.backgroundColor = [UIColor clearColor];
+            [self.viewForBaselineLayout addSubview:self.panView];
+
+            self.panGesture = [[UIPanGestureRecognizer alloc] initWithTarget:self action:@selector(handleGestureAction:)];
+            self.panGesture.delegate = self;
+            [self.panGesture setMaximumNumberOfTouches:1];
+            [self.panView addGestureRecognizer:self.panGesture];
+
+            self.longPressGesture = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleGestureAction:)];
+            self.longPressGesture.minimumPressDuration = 0.1f;
+            [self.panView addGestureRecognizer:self.longPressGesture];
         }
     }
 }
@@ -382,7 +341,7 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
 #pragma mark - Drawing
 
 - (void)didFinishDrawingIncludingYAxis:(BOOL)yAxisFinishedDrawing {
-    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, self.animationGraphEntranceTime * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+    dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t) (self.animationGraphEntranceTime * NSEC_PER_SEC)), dispatch_get_main_queue(), ^{
         if (self.enableYAxisLabel == NO) {
             // Let the delegate know that the graph finished rendering
             if ([self.delegate respondsToSelector:@selector(lineGraphDidFinishDrawing:)])
@@ -402,123 +361,135 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
 - (void)drawEntireGraph {
     // The following method calls are in this specific order for a reason
     // Changing the order of the method calls below can result in drawing glitches and even crashes
-    
+
+    self.averageLine.yValue = NAN;
     self.maxValue = [self getMaximumValue];
     self.minValue = [self getMinimumValue];
-    
+
     // Set the Y-Axis Offset if the Y-Axis is enabled. The offset is relative to the size of the longest label on the Y-Axis.
     if (self.enableYAxisLabel) {
-        NSDictionary *attributes = @{NSFontAttributeName: self.labelFont};
-        if (self.autoScaleYAxis == YES){
-            NSString *maxValueString = [NSString stringWithFormat:self.formatStringForValues, self.maxValue];
-            NSString *minValueString = [NSString stringWithFormat:self.formatStringForValues, self.minValue];
-            
-            NSString *longestString = @"";
-            if (maxValueString.length > minValueString.length) longestString = maxValueString;
-            else longestString = minValueString;
-            
-            NSString *prefix = @"";
-            NSString *suffix = @"";
-            
-            if ([self.delegate respondsToSelector:@selector(yAxisPrefixOnLineGraph:)]) {
-                prefix = [self.delegate yAxisPrefixOnLineGraph:self];
-            }
-            
-            if ([self.delegate respondsToSelector:@selector(yAxisSuffixOnLineGraph:)]) {
-                suffix = [self.delegate yAxisSuffixOnLineGraph:self];
-            }
-            
-            NSString *mString = [longestString stringByReplacingOccurrencesOfString:@"[0-9-]" withString:@"N" options:NSRegularExpressionSearch range:NSMakeRange(0, [longestString length])];
-            NSString *fullString = [NSString stringWithFormat:@"%@%@%@", prefix, mString, suffix];
-            self.YAxisLabelXOffset = [fullString sizeWithAttributes:attributes].width + 2;//MAX([maxValueString sizeWithAttributes:attributes].width + 10,
-                                     //    [minValueString sizeWithAttributes:attributes].width) + 5;
-        } else {
-            NSString *longestString = [NSString stringWithFormat:@"%i", (int)self.frame.size.height];
-            self.YAxisLabelXOffset = [longestString sizeWithAttributes:attributes].width + 5;
-        }
-    } else self.YAxisLabelXOffset = 0;
-
+        self.YAxisLabelXOffset = 2.0f + [self calculateWidestLabel];
+    } else {
+        self.YAxisLabelXOffset = 0;
+    }
     // Draw the X-Axis
     [self drawXAxis];
 
-    // Draw the graph
+    // Draw the data points
     [self drawDots];
 
+    // Draw line with bottom and top fill
+    [self drawLine];
+
     // Draw the Y-Axis
-    if (self.enableYAxisLabel) [self drawYAxis];
+    [self drawYAxis];
+}
+
+-(CGFloat) labelWidthForValue:(CGFloat) value {
+    NSDictionary *attributes = @{NSFontAttributeName: self.labelFont};
+    NSString *valueString = [self yAxisTextForValue:value];
+    NSString *labelString = [valueString stringByReplacingOccurrencesOfString:@"[0-9-]" withString:@"N" options:NSRegularExpressionSearch range:NSMakeRange(0, [valueString length])];
+    return [labelString sizeWithAttributes:attributes].width;
+}
+
+- (CGFloat) calculateWidestLabel {
+    NSDictionary *attributes = @{NSFontAttributeName: self.labelFont};
+    CGFloat widestNumber;
+    if (self.autoScaleYAxis == YES){
+        widestNumber = MAX([self labelWidthForValue:self.maxValue],
+                           [self labelWidthForValue:self.minValue]);
+    } else {
+        widestNumber  = [self labelWidthForValue:self.frame.size.height] ;
+    }
+    return MAX(widestNumber,    [self.averageLine.title sizeWithAttributes:attributes].width);
+}
+
+
+-(BEMCircle *) circleDotAtIndex:(NSUInteger) index forValue:(CGFloat) dotValue reuseNumber: (NSUInteger) reuseNumber {
+    CGFloat positionOnXAxis = numberOfPoints > 1 ?
+        (((self.frame.size.width - self.YAxisLabelXOffset) / (numberOfPoints - 1)) * index) :
+        self.frame.size.width/2;
+    if (self.positionYAxisRight == NO) {
+        positionOnXAxis += self.YAxisLabelXOffset;
+    }
+
+    CGFloat positionOnYAxis = [self yPositionForDotValue:dotValue];
+
+    [yAxisValues addObject:@(positionOnYAxis)];
+
+    if (dotValue >= BEMNullGraphValue) {
+        // If we're dealing with an null value, don't draw the dot (but put it in yAxis to interpolate line)
+        return nil;
+    }
+
+    BEMCircle *circleDot;
+    CGRect dotFrame = CGRectMake(0, 0, self.sizePoint, self.sizePoint);
+    if (reuseNumber < self.circleDots.count) {
+        circleDot = self.circleDots[reuseNumber];
+        circleDot.frame = dotFrame;
+    } else {
+        circleDot = [[BEMCircle alloc] initWithFrame:dotFrame];
+        [self.circleDots addObject:circleDot];
+    }
+
+    circleDot.center = CGPointMake(positionOnXAxis, positionOnYAxis);
+    circleDot.tag = (NSInteger) index + DotFirstTag100;
+    circleDot.absoluteValue = dotValue;
+    circleDot.color = self.colorPoint;
+
+    return circleDot;
+
 }
 
 - (void)drawDots {
-    CGFloat positionOnXAxis; // The position on the X-axis of the point currently being created.
-    CGFloat positionOnYAxis; // The position on the Y-axis of the point currently being created.
-    
-    // Remove all dots that were previously on the graph
-    for (UIView *subview in [self subviews]) {
-        if ([subview isKindOfClass:[BEMCircle class]] || [subview isKindOfClass:[BEMPermanentPopupView class]] || [subview isKindOfClass:[BEMPermanentPopupLabel class]])
-            [subview removeFromSuperview];
-    }
-    
+
     // Remove all data points before adding them to the array
     [dataPoints removeAllObjects];
-    
+
     // Remove all yAxis values before adding them to the array
     [yAxisValues removeAllObjects];
-    
+
     // Loop through each point and add it to the graph
+    NSUInteger circleDotNumber = 0;
     @autoreleasepool {
-        for (int i = 0; i < numberOfPoints; i++) {
+        for (NSUInteger index = 0; index < numberOfPoints; index++) {
             CGFloat dotValue = 0;
-            
-#if !TARGET_INTERFACE_BUILDER
+
+#ifndef TARGET_INTERFACE_BUILDER
             if ([self.dataSource respondsToSelector:@selector(lineGraph:valueForPointAtIndex:)]) {
-                dotValue = [self.dataSource lineGraph:self valueForPointAtIndex:i];
-                
-            } else [NSException raise:@"lineGraph:valueForPointAtIndex: protocol method is not implemented in the data source. Throwing exception here before the system throws a CALayerInvalidGeometry Exception." format:@"Value for point %f at index %lu is invalid. CALayer position may contain NaN: [0 nan]", dotValue, (unsigned long)i];
+                dotValue = [self.dataSource lineGraph:self valueForPointAtIndex:index];
+
+            } else [NSException raise:@"lineGraph:valueForPointAtIndex: protocol method is not implemented in the data source. Throwing exception here before the system throws a CALayerInvalidGeometry Exception." format:@"Value for point %f at index %lu is invalid. CALayer position may contain NaN: [0 nan]", dotValue, (unsigned long)index];
 #else
             dotValue = (int)(arc4random() % 10000);
 #endif
             [dataPoints addObject:@(dotValue)];
-            
-            if (self.positionYAxisRight) {
-                positionOnXAxis = (((self.frame.size.width - self.YAxisLabelXOffset) / (numberOfPoints - 1)) * i);
-            } else {
-                positionOnXAxis = (((self.frame.size.width - self.YAxisLabelXOffset) / (numberOfPoints - 1)) * i) + self.YAxisLabelXOffset;
-            }
-            
-            positionOnYAxis = [self yPositionForDotValue:dotValue];
-            
-            [yAxisValues addObject:@(positionOnYAxis)];
-            
-            
-            // If we're dealing with an null value, don't draw the dot
-            
-            if (dotValue != BEMNullGraphValue) {
-                BEMCircle *circleDot = [[BEMCircle alloc] initWithFrame:CGRectMake(0, 0, self.sizePoint, self.sizePoint)];
-                circleDot.center = CGPointMake(positionOnXAxis, positionOnYAxis);
-                circleDot.tag = i+ DotFirstTag100;
-                circleDot.alpha = 0;
-                circleDot.absoluteValue = dotValue;
-                circleDot.color = self.colorPoint;
-                
-                [self addSubview:circleDot];
-                if (self.alwaysDisplayPopUpLabels == YES) {
-                    if ([self.delegate respondsToSelector:@selector(lineGraph:alwaysDisplayPopUpAtIndex:)]) {
-                        if ([self.delegate lineGraph:self alwaysDisplayPopUpAtIndex:i] == YES) {
-                            [self displayPermanentLabelForPoint:circleDot];
-                        }
-                    } else [self displayPermanentLabelForPoint:circleDot];
+
+            BEMCircle * circleDot = [self circleDotAtIndex: index forValue: dotValue reuseNumber: circleDotNumber];
+            if (circleDot) {
+                if (!circleDot.superview) {
+                    [self addSubview:circleDot];
                 }
-                
+
+                if (self.alwaysDisplayPopUpLabels == YES) {
+                    if (![self.delegate respondsToSelector:@selector(lineGraph:alwaysDisplayPopUpAtIndex:)] ||
+                        [self.delegate lineGraph:self alwaysDisplayPopUpAtIndex:index]) {
+                        BEMPermanentPopupLabel * label =  [self labelForPoint:circleDot reuseNumber: circleDotNumber];
+                        if (label && !label.superview) {
+                            [self addSubview:label];
+                        }
+                    }
+                }
+
                 // Dot entrance animation
-                if (self.animationGraphEntranceTime == 0) {
-                    if (self.displayDotsOnly == YES) circleDot.alpha = 1.0;
-                    else {
-                        if (self.alwaysDisplayDots == NO) circleDot.alpha = 0;
-                        else circleDot.alpha = 1.0;
+                circleDot.alpha = 0;
+                if (self.animationGraphEntranceTime <= 0) {
+                    if (self.displayDotsOnly || self.alwaysDisplayDots ) {
+                        circleDot.alpha = 1.0;
                     }
                 } else {
                     if (self.displayDotsWhileAnimating) {
-                        [UIView animateWithDuration:(float)self.animationGraphEntranceTime/numberOfPoints delay:(float)i*((float)self.animationGraphEntranceTime/numberOfPoints) options:UIViewAnimationOptionCurveLinear animations:^{
+                        [UIView animateWithDuration: self.animationGraphEntranceTime/numberOfPoints delay: index*(self.animationGraphEntranceTime/numberOfPoints) options:UIViewAnimationOptionCurveLinear animations:^{
                             circleDot.alpha = 1.0;
                         } completion:^(BOOL finished) {
                             if (self.alwaysDisplayDots == NO && self.displayDotsOnly == NO) {
@@ -529,22 +500,27 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
                         }];
                     }
                 }
+                circleDotNumber++;
             }
         }
+        for (NSUInteger i = self.circleDots.count -1; i>=circleDotNumber; i--) {
+            [[self.permanentPopups lastObject] removeFromSuperview]; //no harm if not created
+            [self.permanentPopups removeLastObject];
+            [[self.circleDots lastObject] removeFromSuperview];
+            [self.circleDots removeLastObject];
+        }
     }
-    
-    // CREATION OF THE LINE AND BOTTOM AND TOP FILL
-    [self drawLine];
 }
 
 - (void)drawLine {
-    for (UIView *subview in [self subviews]) {
-        if ([subview isKindOfClass:[BEMLine class]])
-            [subview removeFromSuperview];
+    if (!self.masterLine) {
+        self.masterLine = [[BEMLine alloc] initWithFrame:[self drawableGraphArea]];
+        [self addSubview:self.masterLine];
+    } else {
+        self.masterLine.frame = [self drawableGraphArea];
+        [self.masterLine setNeedsDisplay];
     }
-    
-    BEMLine *line = [[BEMLine alloc] initWithFrame:[self drawableGraphArea]];
-    
+    BEMLine * line = self.masterLine;
     line.opaque = NO;
     line.alpha = 1;
     line.backgroundColor = [UIColor clearColor];
@@ -555,7 +531,7 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
     line.topGradient = self.gradientTop;
     line.bottomGradient = self.gradientBottom;
     line.lineWidth = self.widthLine;
-    line.referenceLineWidth = self.widthReferenceLines?self.widthReferenceLines:(self.widthLine/2);
+    line.referenceLineWidth = self.widthReferenceLines > 0.0 ? self.widthReferenceLines : (self.widthLine/2);
     line.lineAlpha = self.alphaLine;
     line.bezierCurveIsEnabled = self.enableBezierCurve;
     line.arrayOfPoints = yAxisValues;
@@ -563,246 +539,182 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
     line.lineDashPatternForReferenceYAxisLines = self.lineDashPatternForReferenceYAxisLines;
     line.lineDashPatternForReferenceXAxisLines = self.lineDashPatternForReferenceXAxisLines;
     line.interpolateNullValues = self.interpolateNullValues;
-    
-    line.enableRefrenceFrame = self.enableReferenceAxisFrame;
+
+    line.enableReferenceFrame = self.enableReferenceAxisFrame;
     line.enableRightReferenceFrameLine = self.enableRightReferenceAxisFrameLine;
     line.enableTopReferenceFrameLine = self.enableTopReferenceAxisFrameLine;
     line.enableLeftReferenceFrameLine = self.enableLeftReferenceAxisFrameLine;
     line.enableBottomReferenceFrameLine = self.enableBottomReferenceAxisFrameLine;
-    
+
     if (self.enableReferenceXAxisLines || self.enableReferenceYAxisLines) {
-        line.enableRefrenceLines = YES;
-        line.refrenceLineColor = self.colorReferenceLines;
+        line.enableReferenceLines = YES;
+        line.referenceLineColor = self.colorReferenceLines;
         line.verticalReferenceHorizontalFringeNegation = xAxisHorizontalFringeNegationValue;
-        line.arrayOfVerticalRefrenceLinePoints = self.enableReferenceXAxisLines ? xAxisLabelPoints : nil;
-        line.arrayOfHorizontalRefrenceLinePoints = self.enableReferenceYAxisLines ? yAxisLabelPoints : nil;
+        line.arrayOfVerticalReferenceLinePoints = self.enableReferenceXAxisLines ? xAxisLabelPoints : nil;
+        line.arrayOfHorizontalReferenceLinePoints = self.enableReferenceYAxisLines ? yAxisLabelPoints : nil;
     }
-    
+
     line.color = self.colorLine;
     line.lineGradient = self.gradientLine;
     line.lineGradientDirection = self.gradientLineDirection;
     line.animationTime = self.animationGraphEntranceTime;
     line.animationType = self.animationGraphStyle;
-    
+
     if (self.averageLine.enableAverageLine == YES) {
-        if (self.averageLine.yValue == 0.0) self.averageLine.yValue = [self calculatePointValueAverage].floatValue;
+        if (isnan(self.averageLine.yValue)) self.averageLine.yValue = [self calculatePointValueAverage].floatValue;
         line.averageLineYCoordinate = [self yPositionForDotValue:self.averageLine.yValue];
         line.averageLine = self.averageLine;
     } else line.averageLine = self.averageLine;
-    
+
     line.disableMainLine = self.displayDotsOnly;
-    
-    [self addSubview:line];
+
     [self sendSubviewToBack:line];
     [self sendSubviewToBack:self.backgroundXAxis];
-    
+
     [self didFinishDrawingIncludingYAxis:NO];
 }
 
 - (void)drawXAxis {
-    if (!self.enableXAxisLabel) return;
+    if (!self.enableXAxisLabel) {
+        [self.backgroundXAxis removeFromSuperview];
+        self.backgroundXAxis = nil;
+        for (UILabel * label in self.xAxisLabels) {
+            [label removeFromSuperview];
+        }
+        self.xAxisLabels = [NSMutableArray array];
+        return;
+    }
     if (![self.dataSource respondsToSelector:@selector(lineGraph:labelOnXAxisForIndex:)]) return;
-    
-    for (UIView *subview in [self subviews]) {
-        if ([subview isKindOfClass:[UILabel class]] && subview.tag == DotLastTag1000) [subview removeFromSuperview];
-        else if ([subview isKindOfClass:[UIView class]] && subview.tag == BackgroundXAxisTag2200) [subview removeFromSuperview];
-    }
-    
-    // Remove all X-Axis Labels before adding them to the array
+
     [xAxisValues removeAllObjects];
-    [xAxisLabels removeAllObjects];
-    [xAxisLabelPoints removeAllObjects];
     xAxisHorizontalFringeNegationValue = 0.0;
-    
+
     // Draw X-Axis Background Area
-    self.backgroundXAxis = [[UIView alloc] initWithFrame:[self drawableXAxisArea]];
-    self.backgroundXAxis.tag = BackgroundXAxisTag2200;
-    if (self.colorBackgroundXaxis == nil) self.backgroundXAxis.backgroundColor = self.colorBottom;
-    else self.backgroundXAxis.backgroundColor = self.colorBackgroundXaxis;
-    self.backgroundXAxis.alpha = self.alphaBackgroundXaxis;
-    [self addSubview:self.backgroundXAxis];
-    
-    if ([self.delegate respondsToSelector:@selector(incrementPositionsForXAxisOnLineGraph:)]) {
-        NSArray *axisValues = [self.delegate incrementPositionsForXAxisOnLineGraph:self];
-        for (NSNumber *increment in axisValues) {
-            NSInteger index = increment.integerValue;
-            NSString *xAxisLabelText = [self xAxisTextForIndex:index];
-            
-            UILabel *labelXAxis = [self xAxisLabelWithText:xAxisLabelText atIndex:index];
-            [xAxisLabels addObject:labelXAxis];
-            
-            if (self.positionYAxisRight) {
-                NSNumber *xAxisLabelCoordinate = [NSNumber numberWithFloat:labelXAxis.center.x];
-                [xAxisLabelPoints addObject:xAxisLabelCoordinate];
-            } else {
-                NSNumber *xAxisLabelCoordinate = [NSNumber numberWithFloat:labelXAxis.center.x-self.YAxisLabelXOffset];
-                [xAxisLabelPoints addObject:xAxisLabelCoordinate];
-            }
-            
-            [self addSubview:labelXAxis];
-            [xAxisValues addObject:xAxisLabelText];
-        }
-    } else if ([self.delegate respondsToSelector:@selector(baseIndexForXAxisOnLineGraph:)] && [self.delegate respondsToSelector:@selector(incrementIndexForXAxisOnLineGraph:)]) {
-        NSInteger baseIndex = [self.delegate baseIndexForXAxisOnLineGraph:self];
-        NSInteger increment = [self.delegate incrementIndexForXAxisOnLineGraph:self];
-        
-        NSInteger startingIndex = baseIndex;
-        while (startingIndex < numberOfPoints) {
-            
-            NSString *xAxisLabelText = [self xAxisTextForIndex:startingIndex];
-            
-            UILabel *labelXAxis = [self xAxisLabelWithText:xAxisLabelText atIndex:startingIndex];
-            [xAxisLabels addObject:labelXAxis];
-            
-            if (self.positionYAxisRight) {
-                NSNumber *xAxisLabelCoordinate = [NSNumber numberWithFloat:labelXAxis.center.x];
-                [xAxisLabelPoints addObject:xAxisLabelCoordinate];
-            } else {
-                NSNumber *xAxisLabelCoordinate = [NSNumber numberWithFloat:labelXAxis.center.x-self.YAxisLabelXOffset];
-                [xAxisLabelPoints addObject:xAxisLabelCoordinate];
-            }
-            
-            [self addSubview:labelXAxis];
-            [xAxisValues addObject:xAxisLabelText];
-            
-            startingIndex += increment;
-        }
+    if (!self.backgroundXAxis) {
+        self.backgroundXAxis = [[UIView alloc] initWithFrame:[self drawableXAxisArea]];
+        [self addSubview:self.backgroundXAxis];
     } else {
-        NSInteger numberOfGaps = 1;
-        
-        if ([self.delegate respondsToSelector:@selector(numberOfGapsBetweenLabelsOnLineGraph:)]) {
-            numberOfGaps = [self.delegate numberOfGapsBetweenLabelsOnLineGraph:self] + 1;
-            
+        self.backgroundXAxis.frame = [self drawableXAxisArea];
+    }
+    self.backgroundXAxis.backgroundColor = self.colorBackgroundXaxis ?: self.colorBottom;
+    self.backgroundXAxis.alpha = self.alphaBackgroundXaxis;
+
+    NSArray <NSNumber *> *axisIndices = nil;
+    if ([self.delegate respondsToSelector:@selector(incrementPositionsForXAxisOnLineGraph:)]) {
+        axisIndices = [self.delegate incrementPositionsForXAxisOnLineGraph:self];
+    } else {
+        NSUInteger baseIndex;
+        NSUInteger increment;
+        if ([self.delegate respondsToSelector:@selector(baseIndexForXAxisOnLineGraph:)] && [self.delegate respondsToSelector:@selector(incrementIndexForXAxisOnLineGraph:)]) {
+            baseIndex = [self.delegate baseIndexForXAxisOnLineGraph:self];
+            increment = [self.delegate incrementIndexForXAxisOnLineGraph:self];
         } else {
-            numberOfGaps = 1;
-        }
-        
-        if (numberOfGaps >= (numberOfPoints - 1)) {
-            NSString *firstXLabel = [self xAxisTextForIndex:0];
-            NSString *lastXLabel = [self xAxisTextForIndex:numberOfPoints - 1];
-            
-            CGFloat viewWidth = self.frame.size.width - self.YAxisLabelXOffset;
-            
-            CGFloat xAxisXPositionFirstOffset;
-            CGFloat xAxisXPositionLastOffset;
-            if (self.positionYAxisRight) {
-                xAxisXPositionFirstOffset = 3;
-                xAxisXPositionLastOffset = xAxisXPositionFirstOffset + 1 + viewWidth/2;
-            } else {
-                xAxisXPositionFirstOffset = 3+self.YAxisLabelXOffset;
-                xAxisXPositionLastOffset = viewWidth/2 + xAxisXPositionFirstOffset + 1;
-            }
-            UILabel *firstLabel = [self xAxisLabelWithText:firstXLabel atIndex:0];
-            firstLabel.frame = CGRectMake(xAxisXPositionFirstOffset, self.frame.size.height-20, viewWidth/2, 20);
-            
-            firstLabel.textAlignment = NSTextAlignmentLeft;
-            [self addSubview:firstLabel];
-            [xAxisValues addObject:firstXLabel];
-            [xAxisLabels addObject:firstLabel];
-            
-            UILabel *lastLabel = [self xAxisLabelWithText:lastXLabel atIndex:numberOfPoints - 1];
-            lastLabel.frame = CGRectMake(xAxisXPositionLastOffset, self.frame.size.height-20, viewWidth/2 - 4, 20);
-            lastLabel.textAlignment = NSTextAlignmentRight;
-            [self addSubview:lastLabel];
-            [xAxisValues addObject:lastXLabel];
-            [xAxisLabels addObject:lastLabel];
-            
-            if (self.positionYAxisRight) {
-                NSNumber *xFirstAxisLabelCoordinate = @(firstLabel.center.x);
-                NSNumber *xLastAxisLabelCoordinate = @(lastLabel.center.x);
-                [xAxisLabelPoints addObject:xFirstAxisLabelCoordinate];
-                [xAxisLabelPoints addObject:xLastAxisLabelCoordinate];
-            } else {
-                NSNumber *xFirstAxisLabelCoordinate = @(firstLabel.center.x - self.YAxisLabelXOffset);
-                NSNumber *xLastAxisLabelCoordinate = @(lastLabel.center.x - self.YAxisLabelXOffset);
-                [xAxisLabelPoints addObject:xFirstAxisLabelCoordinate];
-                [xAxisLabelPoints addObject:xLastAxisLabelCoordinate];
-            }
-        } else {
-            @autoreleasepool {
-                NSInteger offset = [self offsetForXAxisWithNumberOfGaps:numberOfGaps]; // The offset (if possible and necessary) used to shift the Labels on the X-Axis for them to be centered.
-                
-                for (int i = 1; i <= (numberOfPoints/numberOfGaps); i++) {
-                    NSInteger index = i *numberOfGaps - 1 - offset;
-                    NSString *xAxisLabelText = [self xAxisTextForIndex:index];
-                    
-                    UILabel *labelXAxis = [self xAxisLabelWithText:xAxisLabelText atIndex:index];
-                    [xAxisLabels addObject:labelXAxis];
-                    
-                    if (self.positionYAxisRight) {
-                        NSNumber *xAxisLabelCoordinate = [NSNumber numberWithFloat:labelXAxis.center.x];
-                        [xAxisLabelPoints addObject:xAxisLabelCoordinate];
-                    } else {
-                        NSNumber *xAxisLabelCoordinate = [NSNumber numberWithFloat:labelXAxis.center.x - self.YAxisLabelXOffset];
-                        [xAxisLabelPoints addObject:xAxisLabelCoordinate];
-                    }
-                    
-                    [self addSubview:labelXAxis];
-                    [xAxisValues addObject:xAxisLabelText];
+            if ([self.delegate respondsToSelector:@selector(numberOfGapsBetweenLabelsOnLineGraph:)]) {
+                increment = [self.delegate numberOfGapsBetweenLabelsOnLineGraph:self] + 1;
+                if (increment >= numberOfPoints -1) {
+                    //need at least two points
+                    baseIndex = 0;
+                    increment = numberOfPoints - 1;
+                } else {
+                    NSUInteger leftGap = increment - 1;
+                    NSUInteger rightGap = numberOfPoints % increment;
+                    NSUInteger offset = (leftGap-rightGap)/2;
+                    baseIndex = increment - 1 - offset;
                 }
-                
+            } else {
+                increment = 1;
+                baseIndex = 0;
             }
+        }
+        NSMutableArray <NSNumber *> *values = [NSMutableArray array ];
+        NSUInteger index = baseIndex;
+        while (index < numberOfPoints) {
+            [values addObject:@(index)];
+            index += increment;
+        }
+        axisIndices = [values copy];
+    }
+
+    NSUInteger xAxisLabelNumber = 0;
+    @autoreleasepool {
+        for (NSNumber *indexNum in axisIndices) {
+            NSUInteger index = indexNum.unsignedIntegerValue;
+            NSString *xAxisLabelText = [self xAxisTextForIndex:index];
+
+            UILabel *labelXAxis = [self xAxisLabelWithText:xAxisLabelText atIndex:index reuseNumber: xAxisLabelNumber];
+
+            [xAxisLabelPoints addObject:@(labelXAxis.center.x - (self.positionYAxisRight ? self.YAxisLabelXOffset : 0.0f))];
+
+            if (!labelXAxis.superview) [self addSubview:labelXAxis];
+            [xAxisValues addObject:xAxisLabelText];
+            xAxisLabelNumber++;
         }
     }
-    __block NSUInteger lastMatchIndex;
-    
-    NSMutableArray *overlapLabels = [NSMutableArray arrayWithCapacity:0];
-    [xAxisLabels enumerateObjectsUsingBlock:^(UILabel *label, NSUInteger idx, BOOL *stop) {
+    for (NSUInteger i = self.xAxisLabels.count -1; i>=xAxisLabelNumber; i--) {
+        [[self.xAxisLabels lastObject] removeFromSuperview];
+        [self.xAxisLabels removeLastObject];
+    }
+
+    __block UILabel *prevLabel;
+
+    NSMutableArray *overlapLabels = [NSMutableArray arrayWithCapacity:self.xAxisLabels.count];
+    [self.xAxisLabels enumerateObjectsUsingBlock:^(UILabel *label, NSUInteger idx, BOOL *stop) {
         if (idx == 0) {
-            lastMatchIndex = 0;
-        } else { // Skip first one
-            UILabel *prevLabel = [xAxisLabels objectAtIndex:lastMatchIndex];
-            CGRect r = CGRectIntersection(prevLabel.frame, label.frame);
-            if (CGRectIsNull(r)) lastMatchIndex = idx;
-            else [overlapLabels addObject:label]; // Overlapped
-        }
-        
-        BOOL fullyContainsLabel = CGRectContainsRect(self.bounds, label.frame);
-        if (!fullyContainsLabel) {
-            [overlapLabels addObject:label];
+            prevLabel = label; //always show first label
+        } else if (label.superview) { //only look at active labels
+            if (CGRectIsNull(CGRectIntersection(prevLabel.frame, label.frame)) &&
+                CGRectContainsRect(self.backgroundXAxis.frame, label.frame)) {
+                prevLabel = label;  //no overlap and inside frame, so show this one
+            } else {
+                //                NSLog(@"Not showing %@ due to %@; label: %@, width: %@ prevLabel: %@, frame: %@",
+                //                      label.text,
+                //                      CGRectIsNull(CGRectIntersection(prevLabel.frame, label.frame)) ?@"Overlap" : @"Out of bounds",
+                //                      NSStringFromCGRect(label.frame),
+                //                      @(CGRectGetMaxX(label.frame)),
+                //                      NSStringFromCGRect(prevLabel.frame),
+                //                      NSStringFromCGRect(self.backgroundXAxis.frame));
+                [overlapLabels addObject:label]; // Overlapped
+            }
         }
     }];
-    
+
     for (UILabel *l in overlapLabels) {
         [l removeFromSuperview];
     }
 }
 
-- (NSString *)xAxisTextForIndex:(NSInteger)index {
+- (NSString *)xAxisTextForIndex:(NSUInteger)index {
     NSString *xAxisLabelText = @"";
-    
+
     if ([self.dataSource respondsToSelector:@selector(lineGraph:labelOnXAxisForIndex:)]) {
         xAxisLabelText = [self.dataSource lineGraph:self labelOnXAxisForIndex:index];
-        
     } else  {
         xAxisLabelText = @"";
     }
-    
+
     return xAxisLabelText;
 }
 
-- (UILabel *)xAxisLabelWithText:(NSString *)text atIndex:(NSInteger)index {
-    UILabel *labelXAxis = [[UILabel alloc] init];
+- (UILabel *)xAxisLabelWithText:(NSString *)text atIndex:(NSUInteger)index reuseNumber:(NSUInteger) xAxisLabelNumber{
+    UILabel *labelXAxis;
+    if (xAxisLabelNumber < self.xAxisLabels.count) {
+        labelXAxis = self.xAxisLabels[xAxisLabelNumber];
+    } else {
+        labelXAxis = [[UILabel alloc] init];
+        [self.xAxisLabels addObject:labelXAxis];
+    }
+
     labelXAxis.text = text;
     labelXAxis.font = self.labelFont;
     labelXAxis.textAlignment = 1;
     labelXAxis.textColor = self.colorXaxisLabel;
     labelXAxis.backgroundColor = [UIColor clearColor];
-    labelXAxis.tag = DotLastTag1000;
-    
+
     // Add support multi-line, but this might overlap with the graph line if text have too many lines
     labelXAxis.numberOfLines = 0;
     CGRect lRect = [labelXAxis.text boundingRectWithSize:self.viewForBaselineLayout.frame.size options:NSStringDrawingUsesLineFragmentOrigin attributes:@{NSFontAttributeName:labelXAxis.font} context:nil];
-    
-    CGPoint center;
-    
-    /* OLD LABEL GENERATION CODE
-    CGFloat availablePositionRoom = self.viewForBaselineLayout.frame.size.width; // Get view width of view
-    CGFloat positioningDivisor = (float)index / numberOfPoints; // Generate relative position of point based on current index and total
-    CGFloat horizontalTranslation = self.YAxisLabelXOffset + lRect.size.width;
-    CGFloat xPosition = (availablePositionRoom * positioningDivisor) + horizontalTranslation;
-    // NSLog(@"availablePositionRoom: %f, positioningDivisor: %f, horizontalTranslation: %f, xPosition: %f", availablePositionRoom, positioningDivisor, horizontalTranslation, xPosition); // Uncomment for debugging */
-    
+
+
     // Determine the horizontal translation to perform on the far left and far right labels
     // This property is negated when calculating the position of reference frames
     CGFloat horizontalTranslation;
@@ -812,302 +724,341 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
         horizontalTranslation = -lRect.size.width/2;
     } else horizontalTranslation = 0;
     xAxisHorizontalFringeNegationValue = horizontalTranslation;
-    
+
     // Determine the final x-axis position
-    CGFloat positionOnXAxis;
-    if (self.positionYAxisRight) {
-        positionOnXAxis = (((self.frame.size.width - self.YAxisLabelXOffset) / (numberOfPoints - 1)) * index) + horizontalTranslation;
-    } else {
-        positionOnXAxis = (((self.frame.size.width - self.YAxisLabelXOffset) / (numberOfPoints - 1)) * index) + self.YAxisLabelXOffset + horizontalTranslation;
+    CGFloat positionOnXAxis =  (((self.frame.size.width - self.YAxisLabelXOffset) / (numberOfPoints - 1)) * index) + horizontalTranslation;
+    if (!self.positionYAxisRight) {
+        positionOnXAxis += self.YAxisLabelXOffset;
     }
-    
-    // Set the final center point of the x-axis labels
-    center = CGPointMake(positionOnXAxis, self.frame.size.height - lRect.size.height/2 - 1);
-    
-    CGRect rect = labelXAxis.frame;
-    rect.size = lRect.size;
-    labelXAxis.frame = rect;
-    labelXAxis.center = center;
+
+    labelXAxis.frame = lRect;
+    labelXAxis.center = CGPointMake(positionOnXAxis, self.frame.size.height - lRect.size.height/2.0f-1.0f);
     return labelXAxis;
 }
 
-- (void)drawYAxis {
-    for (UIView *subview in [self subviews]) {
-        if ([subview isKindOfClass:[UILabel class]] && subview.tag == LabelYAxisTag2000 ) {
-            [subview removeFromSuperview];
-        } else if ([subview isKindOfClass:[UIView class]] && subview.tag == BackgroundYAxisTag2100 ) {
-            [subview removeFromSuperview];
-        }
-    }
-    
-    CGRect frameForBackgroundYAxis;
-    CGRect frameForLabelYAxis;
-    CGFloat xValueForCenterLabelYAxis;
-    NSTextAlignment textAlignmentForLabelYAxis;
-    
-    if (self.positionYAxisRight) {
-        frameForBackgroundYAxis = CGRectMake(self.frame.size.width - self.YAxisLabelXOffset, 0, self.YAxisLabelXOffset, self.frame.size.height);
-        frameForLabelYAxis = CGRectMake(self.frame.size.width - self.YAxisLabelXOffset - 1, 0, self.YAxisLabelXOffset - 1, 15);
-        xValueForCenterLabelYAxis = self.frame.size.width - (self.YAxisLabelXOffset-1)/2;
-        textAlignmentForLabelYAxis = NSTextAlignmentRight;
-    } else {
-        frameForBackgroundYAxis = CGRectMake(0, 0, self.YAxisLabelXOffset, self.frame.size.height);
-        frameForLabelYAxis = CGRectMake(1, 0, self.YAxisLabelXOffset - 1, 15);
-        xValueForCenterLabelYAxis = (self.YAxisLabelXOffset-1)/2;
-        textAlignmentForLabelYAxis = NSTextAlignmentRight;
-    }
-    
-    UIView *backgroundYaxis = [[UIView alloc] initWithFrame:frameForBackgroundYAxis];
-    backgroundYaxis.tag = BackgroundYAxisTag2100;
-    if (self.colorBackgroundYaxis == nil) backgroundYaxis.backgroundColor = self.colorTop;
-    else backgroundYaxis.backgroundColor = self.colorBackgroundYaxis;
-    backgroundYaxis.alpha = self.alphaBackgroundYaxis;
-    [self addSubview:backgroundYaxis];
-    
-    NSMutableArray *yAxisLabels = [NSMutableArray arrayWithCapacity:0];
-    [yAxisLabelPoints removeAllObjects];
-    
+-(NSString *) yAxisTextForValue:(CGFloat) value {
     NSString *yAxisSuffix = @"";
     NSString *yAxisPrefix = @"";
-    
+
     if ([self.delegate respondsToSelector:@selector(yAxisPrefixOnLineGraph:)]) yAxisPrefix = [self.delegate yAxisPrefixOnLineGraph:self];
     if ([self.delegate respondsToSelector:@selector(yAxisSuffixOnLineGraph:)]) yAxisSuffix = [self.delegate yAxisSuffixOnLineGraph:self];
-    
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+   NSString *formattedValue = [NSString stringWithFormat:self.formatStringForValues, value];
+#pragma clang diagnostic pop
+
+    return [NSString stringWithFormat:@"%@%@%@", yAxisPrefix, formattedValue, yAxisSuffix];
+}
+
+- (UILabel *)yAxisLabelWithText:(NSString *)text atValue:(CGFloat)value reuseNumber:(NSUInteger) reuseNumber {
+    //provide a Y-Axis Label with text at Value, reusing reuseNumber'd label if it exists
+    //special case: use self.Averageline.label if reuseNumber = NSIntegerMax
+    CGFloat labelHeight = self.labelFont.pointSize + 7.0f;
+    CGRect frameForLabelYAxis = CGRectMake(1.0f, 0.0f, self.YAxisLabelXOffset - 1.0f, labelHeight);
+
+    CGFloat xValueForCenterLabelYAxis = (self.YAxisLabelXOffset-1.0f) /2.0f;
+    NSTextAlignment textAlignmentForLabelYAxis = NSTextAlignmentRight;
+    if (self.positionYAxisRight) {
+        frameForLabelYAxis.origin = CGPointMake(self.frame.size.width - self.YAxisLabelXOffset - 1.0f, 0.0f);
+        xValueForCenterLabelYAxis = self.frame.size.width - xValueForCenterLabelYAxis;
+    }
+
+    UILabel *labelYAxis;
+    if ( reuseNumber == NSIntegerMax) {
+        if (!self.averageLine.label) {
+            self.averageLine.label = [[UILabel alloc] initWithFrame:frameForLabelYAxis];
+        }
+        labelYAxis = self.averageLine.label;
+    } else if (reuseNumber < self.yAxisLabels.count) {
+        labelYAxis = self.yAxisLabels[reuseNumber];
+    } else {
+        labelYAxis = [[UILabel alloc] initWithFrame:frameForLabelYAxis];
+        [self.yAxisLabels addObject:labelYAxis];
+    }
+    labelYAxis.text = text;
+    labelYAxis.textAlignment = textAlignmentForLabelYAxis;
+    labelYAxis.font = self.labelFont;
+    labelYAxis.textColor = self.colorYaxisLabel;
+    labelYAxis.backgroundColor = [UIColor clearColor];
+    CGFloat yAxisPosition = [self yPositionForDotValue:value];
+    labelYAxis.center = CGPointMake(xValueForCenterLabelYAxis, yAxisPosition);
+
+    NSNumber *yAxisLabelCoordinate = @(labelYAxis.center.y);
+    [yAxisLabelPoints addObject:yAxisLabelCoordinate];
+    return labelYAxis;
+}
+
+- (void)drawYAxis {
+    if (!self.enableYAxisLabel) {
+        [self.backgroundYAxis removeFromSuperview];
+        self.backgroundYAxis = nil;
+        for (UILabel * label in self.yAxisLabels) {
+            [label removeFromSuperview];
+        }
+        self.yAxisLabels = [NSMutableArray array];
+        return;
+    }
+
+    //Make Background for Y Axis
+    CGRect frameForBackgroundYAxis = CGRectMake(
+                                                (self.positionYAxisRight ?
+                                                    self.frame.size.width - self.YAxisLabelXOffset - 1:
+                                                    1),
+                                                0,
+                                                self.YAxisLabelXOffset -1,
+                                                self.frame.size.height);
+
+    if (!self.backgroundYAxis) {
+        self.backgroundYAxis= [[UIView alloc] initWithFrame:frameForBackgroundYAxis];
+        [self addSubview:self.backgroundYAxis];
+    } else {
+        self.backgroundYAxis.frame = frameForBackgroundYAxis;
+    }
+    self.backgroundYAxis.backgroundColor = self.colorBackgroundYaxis ?: self.colorTop;
+    self.backgroundYAxis.alpha = self.alphaBackgroundYaxis;
+
+    [yAxisLabelPoints removeAllObjects];
+
+    NSUInteger numberOfLabels = 3;
+    if ([self.delegate respondsToSelector:@selector(numberOfYAxisLabelsOnLineGraph:)]) {
+        numberOfLabels = [self.delegate numberOfYAxisLabelsOnLineGraph:self];
+        if (numberOfLabels <= 0) return;
+    }
+
+    //Now calculate baseValue and increment for all scenarios
+    CGFloat value;
+    CGFloat increment;
     if (self.autoScaleYAxis) {
         // Plot according to min-max range
-        NSNumber *minimumValue;
-        NSNumber *maximumValue;
+        CGFloat minValue = [self calculateMinimumPointValue].floatValue;
+        CGFloat maxValue = [self calculateMaximumPointValue].floatValue;
 
-        minimumValue = [self calculateMinimumPointValue];
-        maximumValue = [self calculateMaximumPointValue];
-        
-        CGFloat numberOfLabels;
-        if ([self.delegate respondsToSelector:@selector(numberOfYAxisLabelsOnLineGraph:)]) {
-            numberOfLabels = [self.delegate numberOfYAxisLabelsOnLineGraph:self];
-        } else numberOfLabels = 3;
-        
-        NSMutableArray *dotValues = [[NSMutableArray alloc] initWithCapacity:numberOfLabels];
-        if ([self.delegate respondsToSelector:@selector(baseValueForYAxisOnLineGraph:)] && [self.delegate respondsToSelector:@selector(incrementValueForYAxisOnLineGraph:)]) {
-            CGFloat baseValue = [self.delegate baseValueForYAxisOnLineGraph:self];
-            CGFloat increment = [self.delegate incrementValueForYAxisOnLineGraph:self];
-            
-            float yAxisPosition = baseValue;
-            if (baseValue + increment * 100 < maximumValue.doubleValue) {
-                NSLog(@"[BEMSimpleLineGraph] Increment does not properly lay out Y axis, bailing early");
-                return;
-            }
-            
-            while(yAxisPosition < maximumValue.floatValue + increment) {
-                [dotValues addObject:@(yAxisPosition)];
-                yAxisPosition += increment;
-            }
-        } else if (numberOfLabels <= 0) return;
-        else if (numberOfLabels == 1) {
-            [dotValues removeAllObjects];
-            [dotValues addObject:[NSNumber numberWithInt:(minimumValue.intValue + maximumValue.intValue)/2]];
+        if (numberOfLabels == 1) {
+            value = (minValue + maxValue)/2.0f;
+            increment = 0; //NA
         } else {
-            [dotValues addObject:minimumValue];
-            [dotValues addObject:maximumValue];
-            for (int i=1; i<numberOfLabels-1; i++) {
-                [dotValues addObject:[NSNumber numberWithFloat:(minimumValue.doubleValue + ((maximumValue.doubleValue - minimumValue.doubleValue)/(numberOfLabels-1))*i)]];
+            value = minValue;
+            increment = (maxValue - minValue)/(numberOfLabels-1);
+            if ([self.delegate respondsToSelector:@selector(baseValueForYAxisOnLineGraph:)] && [self.delegate respondsToSelector:@selector(incrementValueForYAxisOnLineGraph:)]) {
+                value = [self.delegate baseValueForYAxisOnLineGraph:self];
+                increment = [self.delegate incrementValueForYAxisOnLineGraph:self];
+                numberOfLabels = (NSUInteger) ((maxValue - value)/increment)+1;
+                if (numberOfLabels > 100) {
+                    NSLog(@"[BEMSimpleLineGraph] Increment does not properly lay out Y axis, bailing early");
+                    return;
+                }
             }
-        }
-        
-        for (NSNumber *dotValue in dotValues) {
-            CGFloat yAxisPosition = [self yPositionForDotValue:dotValue.floatValue];
-            UILabel *labelYAxis = [[UILabel alloc] initWithFrame:frameForLabelYAxis];
-            NSString *formattedValue = [NSString stringWithFormat:self.formatStringForValues, dotValue.doubleValue];
-            labelYAxis.text = [NSString stringWithFormat:@"%@%@%@", yAxisPrefix, formattedValue, yAxisSuffix];
-            labelYAxis.textAlignment = textAlignmentForLabelYAxis;
-            labelYAxis.font = self.labelFont;
-            labelYAxis.textColor = self.colorYaxisLabel;
-            labelYAxis.backgroundColor = [UIColor clearColor];
-            labelYAxis.tag = LabelYAxisTag2000;
-            labelYAxis.center = CGPointMake(xValueForCenterLabelYAxis, yAxisPosition);
-            [self addSubview:labelYAxis];
-            [yAxisLabels addObject:labelYAxis];
-            
-            NSNumber *yAxisLabelCoordinate = @(labelYAxis.center.y);
-            [yAxisLabelPoints addObject:yAxisLabelCoordinate];
         }
     } else {
-        NSInteger numberOfLabels;
-        if ([self.delegate respondsToSelector:@selector(numberOfYAxisLabelsOnLineGraph:)]) numberOfLabels = [self.delegate numberOfYAxisLabelsOnLineGraph:self];
-        else numberOfLabels = 3;
-        
-        CGFloat graphHeight = self.frame.size.height;
-        CGFloat graphSpacing = (graphHeight - self.XAxisLabelYOffset) / numberOfLabels;
-        
-        CGFloat yAxisPosition = graphHeight - self.XAxisLabelYOffset + graphSpacing/2;
-        
-        for (NSInteger i = numberOfLabels; i > 0; i--) {
-            yAxisPosition -= graphSpacing;
-            
-            UILabel *labelYAxis = [[UILabel alloc] initWithFrame:frameForLabelYAxis];
-            labelYAxis.center = CGPointMake(xValueForCenterLabelYAxis, yAxisPosition);
-            labelYAxis.text = [NSString stringWithFormat:self.formatStringForValues, (graphHeight - self.XAxisLabelYOffset - yAxisPosition)];
-            labelYAxis.font = self.labelFont;
-            labelYAxis.textAlignment = textAlignmentForLabelYAxis;
-            labelYAxis.textColor = self.colorYaxisLabel;
-            labelYAxis.backgroundColor = [UIColor clearColor];
-            labelYAxis.tag = LabelYAxisTag2000;
-            
-            [self addSubview:labelYAxis];
-            
-            [yAxisLabels addObject:labelYAxis];
-            
-            NSNumber *yAxisLabelCoordinate = @(labelYAxis.center.y);
-            [yAxisLabelPoints addObject:yAxisLabelCoordinate];
+        //not AutoScale
+        CGFloat graphHeight = self.frame.size.height - self.XAxisLabelYOffset;
+        if (numberOfLabels == 1) {
+            value = graphHeight/2.0f;
+            increment = 0; //NA
+        } else {
+            increment = graphHeight / numberOfLabels;
+            value = increment/2;
         }
     }
-    
-    // Detect overlapped labels
-    __block NSUInteger lastMatchIndex = 0;
-    NSMutableArray *overlapLabels = [NSMutableArray arrayWithCapacity:0];
-    
-    [yAxisLabels enumerateObjectsUsingBlock:^(UILabel *label, NSUInteger idx, BOOL *stop) {
-        
-        if (idx==0) lastMatchIndex = 0;
-        else { // Skip first one
-            UILabel *prevLabel = yAxisLabels[lastMatchIndex];
-            CGRect r = CGRectIntersection(prevLabel.frame, label.frame);
-            if (CGRectIsNull(r)) lastMatchIndex = idx;
-            else [overlapLabels addObject:label]; // overlapped
+    NSMutableArray *dotValues = [[NSMutableArray alloc] initWithCapacity:numberOfLabels];
+    for (NSUInteger i = 0; i < numberOfLabels; i++) {
+        [dotValues addObject:@(value)];
+        value += increment;
+    }
+    NSUInteger yAxisLabelNumber = 0;
+    @autoreleasepool {
+        for (NSNumber *dotValueNum in dotValues) {
+            CGFloat dotValue = dotValueNum.floatValue;
+            NSString *labelText = [self yAxisTextForValue:dotValue];
+            UILabel *labelYAxis = [self yAxisLabelWithText:labelText
+                                                   atValue:dotValue
+                                               reuseNumber:yAxisLabelNumber];
+
+            if (!labelYAxis.superview) [self addSubview:labelYAxis];
+            yAxisLabelNumber++;
         }
-        
-        // Axis should fit into our own view
-        BOOL fullyContainsLabel = CGRectContainsRect(self.bounds, label.frame);
-        if (!fullyContainsLabel) {
-            [overlapLabels addObject:label];
-            [yAxisLabelPoints removeObject:@(label.center.y)];
+    }
+
+    for (NSUInteger i = self.yAxisLabels.count -1; i>=yAxisLabelNumber; i--) {
+        [[self.yAxisLabels lastObject] removeFromSuperview];
+        [self.yAxisLabels removeLastObject];
+    }
+
+    // Detect overlapped labels
+    __block UILabel * prevLabel = nil;;
+    NSMutableArray *overlapLabels = [NSMutableArray arrayWithCapacity:0];
+
+    [self.yAxisLabels enumerateObjectsUsingBlock:^(UILabel *label, NSUInteger idx, BOOL *stop) {
+
+        if (idx == 0) {
+            prevLabel = label; //always show first label
+        } else if (label.superview) { //only look at active labels
+            if (CGRectIsNull(CGRectIntersection(prevLabel.frame, label.frame)) &&
+                CGRectContainsRect(self.backgroundYAxis.bounds, label.frame)) {
+                prevLabel = label;  //no overlap and inside frame, so show this one
+            } else {
+                [overlapLabels addObject:label]; // Overlapped
+//                NSLog(@"Not showing %@ due to %@; label: %@, width: %@ prevLabel: %@, frame: %@",
+//                      label.text,
+//                      CGRectIsNull(CGRectIntersection(prevLabel.frame, label.frame)) ?@"Overlap" : @"Out of bounds",
+//                      NSStringFromCGRect(label.frame),
+//                      @(CGRectGetMaxX(label.frame)),
+//                      NSStringFromCGRect(prevLabel.frame),
+//                      NSStringFromCGRect(self.backgroundXAxis.frame));
+            }
         }
     }];
-    
+
+
+    if (self.averageLine.enableAverageLine && self.averageLine.title.length > 0) {
+
+        UILabel *averageLabel = [self yAxisLabelWithText:self.averageLine.title
+                                               atValue:self.averageLine.yValue
+                                           reuseNumber:NSIntegerMax];
+
+        if (!averageLabel.superview) [self addSubview:averageLabel];
+
+        //check for overlap; Average wins
+        for (UILabel * label in self.yAxisLabels) {
+            if (! CGRectIsNull(CGRectIntersection(averageLabel.frame, label.frame))) {
+                [overlapLabels addObject:label];
+            }
+        }
+    }
+
     for (UILabel *label in overlapLabels) {
         [label removeFromSuperview];
     }
-    
-    [self didFinishDrawingIncludingYAxis:YES];  
+
+    [self didFinishDrawingIncludingYAxis:YES];
 }
 
 /// Area on the graph that doesn't include the axes
-- (CGRect)drawableGraphArea {
-//  CGRectMake(xAxisXPositionFirstOffset, self.frame.size.height-20, viewWidth/2, 20);
-    NSInteger xAxisHeight = 20;
+- (CGRect) drawableGraphArea {
+    //  CGRectMake(xAxisXPositionFirstOffset, self.frame.size.height-20, viewWidth/2, 20);
+    CGFloat xAxisHeight = self.labelFont.pointSize + 8.0f;
     CGFloat xOrigin = self.positionYAxisRight ? 0 : self.YAxisLabelXOffset;
     CGFloat viewWidth = self.frame.size.width - self.YAxisLabelXOffset;
     CGFloat adjustedHeight = self.bounds.size.height - xAxisHeight;
-    
+
     CGRect rect = CGRectMake(xOrigin, 0, viewWidth, adjustedHeight);
     return rect;
 }
 
 - (CGRect)drawableXAxisArea {
-    NSInteger xAxisHeight = 20;
-    NSInteger xAxisWidth = [self drawableGraphArea].size.width + 1;
+    CGFloat xAxisHeight = self.labelFont.pointSize + 8.0f;
+    CGFloat xAxisWidth = [self drawableGraphArea].size.width + 1;
     CGFloat xAxisXOrigin = self.positionYAxisRight ? 0 : self.YAxisLabelXOffset;
     CGFloat xAxisYOrigin = self.bounds.size.height - xAxisHeight;
     return CGRectMake(xAxisXOrigin, xAxisYOrigin, xAxisWidth, xAxisHeight);
 }
 
-/// Calculates the optimum offset needed for the Labels to be centered on the X-Axis.
-- (NSInteger)offsetForXAxisWithNumberOfGaps:(NSInteger)numberOfGaps {
-    NSInteger leftGap = numberOfGaps - 1;
-    NSInteger rightGap = numberOfPoints - (numberOfGaps*(numberOfPoints/numberOfGaps));
-    NSInteger offset = 0;
-    
-    if (leftGap != rightGap) {
-        for (int i = 0; i <= numberOfGaps; i++) {
-            if (leftGap - i == rightGap + i) {
-                offset = i;
-            }
+- (BEMPermanentPopupLabel *)labelForPoint:(BEMCircle *)circleDot reuseNumber: (NSUInteger) reuseNumber {
+
+    BOOL touchPopUp =   reuseNumber == NSIntegerMax;
+    NSUInteger index = (NSUInteger) circleDot.tag - DotFirstTag100;
+
+    BEMPermanentPopupLabel *popUpLabel;
+    if ( touchPopUp) {
+        if (!self.popUpLabel) {
+            self.popUpLabel =[[BEMPermanentPopupLabel alloc] init];
+            [self addSubview:self.popUpLabel];
+        }
+    } else if (reuseNumber < self.permanentPopups.count) {
+        popUpLabel = self.permanentPopups[reuseNumber];
+    } else {
+        popUpLabel = [[BEMPermanentPopupLabel alloc] init];
+        [self.permanentPopups addObject:popUpLabel];
+    }
+
+    popUpLabel.textAlignment = NSTextAlignmentCenter;
+    popUpLabel.numberOfLines = 0;
+    popUpLabel.font = self.labelFont;
+    popUpLabel.backgroundColor = [UIColor clearColor];
+    popUpLabel.layer.backgroundColor = [self.colorBackgroundPopUplabel colorWithAlphaComponent:0.7f].CGColor;
+    popUpLabel.layer.cornerRadius = 6;
+    popUpLabel.alpha = 0;
+
+    if ([self.delegate respondsToSelector:@selector(popUpTextForlineGraph:atIndex:)]) {
+        popUpLabel.text = [self.delegate popUpTextForlineGraph:self atIndex:index];
+    } else {
+        NSString *prefix = @"";
+        NSString *suffix = @"";
+
+        if ([self.delegate respondsToSelector:@selector(popUpSuffixForlineGraph:)])
+            suffix = [self.delegate popUpSuffixForlineGraph:self];
+
+        if ([self.delegate respondsToSelector:@selector(popUpPrefixForlineGraph:)])
+            prefix = [self.delegate popUpPrefixForlineGraph:self];
+
+        NSNumber *value = (index <= dataPoints.count) ? value = dataPoints[index] : @(0); // @((NSInteger) circleDot.absoluteValue)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wformat-nonliteral"
+        NSString *formattedValue = [NSString stringWithFormat:self.formatStringForValues, value.doubleValue];
+#pragma clang diagnostic pop
+        popUpLabel.text = [NSString stringWithFormat:@"%@%@%@", prefix, formattedValue, suffix];
+    }
+
+    [popUpLabel sizeToFit];
+    popUpLabel.frame = CGRectMake(0, 0, popUpLabel.frame.size.width + 7, popUpLabel.frame.size.height + 2);
+
+    //now fixup left/right problems
+    CGFloat xCenter = circleDot.center.x;
+    CGFloat halfLabelWidth = popUpLabel.frame.size.width/2 ;
+    if (self.enableYAxisLabel && !self.positionYAxisRight && ((xCenter - halfLabelWidth) <= self.YAxisLabelXOffset) ) {
+        //bumping into left Y axis
+        xCenter = halfLabelWidth + self.YAxisLabelXOffset + 4.0f;
+    } else if (self.enableYAxisLabel && self.positionYAxisRight && (xCenter + halfLabelWidth >= self.frame.size.width - self.YAxisLabelXOffset)) {
+        //bumping into right Y axis
+        xCenter = self.frame.size.width - halfLabelWidth  - self.YAxisLabelXOffset - 4.0f;
+    } else if (xCenter - halfLabelWidth <= 0) {
+        //over left edge
+        xCenter = halfLabelWidth + 4.0f;
+    } else if (xCenter + halfLabelWidth >= self.frame.size.width) {
+        //over right edge
+        xCenter = self.frame.size.width - halfLabelWidth;
+    }
+
+    //now set y directions
+    //default is over point
+    CGFloat halfLabelHeight = popUpLabel.frame.size.height/2.0f;
+    CGFloat yCenter = circleDot.frame.origin.y - 2.0f - halfLabelHeight;
+    popUpLabel.center = CGPointMake(xCenter, yCenter);
+
+    CGRect leftNeighborFrame = (reuseNumber >= 1) ? self.permanentPopups[reuseNumber-1].frame : CGRectNull;
+    CGRect secondNeighborFrame = (reuseNumber >= 2) ? self.permanentPopups[reuseNumber-2].frame : CGRectNull;
+    //check for bumping into top OR overlap with left neighbors
+    if (CGRectGetMinY(popUpLabel.frame) < 2.0f ||
+        (!CGRectIsNull(leftNeighborFrame) && !CGRectIsNull(CGRectIntersection(popUpLabel.frame, leftNeighborFrame))) ||
+        (!CGRectIsNull(secondNeighborFrame) && !CGRectIsNull(CGRectIntersection(popUpLabel.frame, secondNeighborFrame)))) {
+        //if so, try below point instead
+        CGRect frame = popUpLabel.frame;
+        frame.origin.y = CGRectGetMaxY(circleDot.frame)+2.0f;
+        popUpLabel.frame = frame;
+        //check for bottom and again for overlap with neighbor and even neighbor second to the left
+        if (CGRectGetMaxY(frame) > (self.frame.size.height - self.XAxisLabelYOffset) ||
+            (!CGRectIsNull(leftNeighborFrame) && !CGRectIsNull(CGRectIntersection(popUpLabel.frame, leftNeighborFrame))) ||
+            (!CGRectIsNull(secondNeighborFrame) && !CGRectIsNull(CGRectIntersection(popUpLabel.frame, secondNeighborFrame)))) {
+            return nil;
         }
     }
-    
-    return offset;
-}
 
-- (void)displayPermanentLabelForPoint:(BEMCircle *)circleDot {
-    self.enablePopUpReport = NO;
-    self.xCenterLabel = circleDot.center.x;
-    
-    BEMPermanentPopupLabel *permanentPopUpLabel = [[BEMPermanentPopupLabel alloc] init];
-    permanentPopUpLabel.textAlignment = NSTextAlignmentCenter;
-    permanentPopUpLabel.numberOfLines = 0;
-    
-    NSString *prefix = @"";
-    NSString *suffix = @"";
-    
-    if ([self.delegate respondsToSelector:@selector(popUpSuffixForlineGraph:)])
-        suffix = [self.delegate popUpSuffixForlineGraph:self];
-
-    if ([self.delegate respondsToSelector:@selector(popUpPrefixForlineGraph:)])
-        prefix = [self.delegate popUpPrefixForlineGraph:self];
-
-    int index = (int)(circleDot.tag - DotFirstTag100);
-    NSNumber *value = dataPoints[index]; // @((NSInteger) circleDot.absoluteValue)
-    NSString *formattedValue = [NSString stringWithFormat:self.formatStringForValues, value.doubleValue];
-    permanentPopUpLabel.text = [NSString stringWithFormat:@"%@%@%@", prefix, formattedValue, suffix];
-    
-    permanentPopUpLabel.font = self.labelFont;
-    permanentPopUpLabel.backgroundColor = [UIColor clearColor];
-    [permanentPopUpLabel sizeToFit];
-    permanentPopUpLabel.center = CGPointMake(self.xCenterLabel, circleDot.center.y - circleDot.frame.size.height/2 - 15);
-    permanentPopUpLabel.alpha = 0;
-    
-    BEMPermanentPopupView *permanentPopUpView = [[BEMPermanentPopupView alloc] initWithFrame:CGRectMake(0, 0, permanentPopUpLabel.frame.size.width + 7, permanentPopUpLabel.frame.size.height + 2)];
-    permanentPopUpView.backgroundColor = self.colorBackgroundPopUplabel;
-    permanentPopUpView.alpha = 0;
-    permanentPopUpView.layer.cornerRadius = 3;
-    permanentPopUpView.tag = PermanentPopUpViewTag3100;
-    permanentPopUpView.center = permanentPopUpLabel.center;
-    
-    if (permanentPopUpLabel.frame.origin.x <= 0) {
-        self.xCenterLabel = permanentPopUpLabel.frame.size.width/2 + 4;
-        permanentPopUpLabel.center = CGPointMake(self.xCenterLabel, circleDot.center.y - circleDot.frame.size.height/2 - 15);
-    } else if (self.enableYAxisLabel == YES && permanentPopUpLabel.frame.origin.x <= self.YAxisLabelXOffset) {
-        self.xCenterLabel = permanentPopUpLabel.frame.size.width/2 + 4;
-        permanentPopUpLabel.center = CGPointMake(self.xCenterLabel + self.YAxisLabelXOffset, circleDot.center.y - circleDot.frame.size.height/2 - 15);
-    } else if ((permanentPopUpLabel.frame.origin.x + permanentPopUpLabel.frame.size.width) >= self.frame.size.width) {
-        self.xCenterLabel = self.frame.size.width - permanentPopUpLabel.frame.size.width/2 - 4;
-        permanentPopUpLabel.center = CGPointMake(self.xCenterLabel, circleDot.center.y - circleDot.frame.size.height/2 - 15);
-    }
-    
-    if (permanentPopUpLabel.frame.origin.y <= 2) {
-        permanentPopUpLabel.center = CGPointMake(self.xCenterLabel, circleDot.center.y + circleDot.frame.size.height/2 + 15);
-    }
-    
-    if ([self checkOverlapsForView:permanentPopUpView] == YES) {
-        permanentPopUpLabel.center = CGPointMake(self.xCenterLabel, circleDot.center.y + circleDot.frame.size.height/2 + 15);
-    }
-    
-    permanentPopUpView.center = permanentPopUpLabel.center;
-    
-    [self addSubview:permanentPopUpView];
-    [self addSubview:permanentPopUpLabel];
-    
-    if (self.animationGraphEntranceTime == 0) {
-        permanentPopUpLabel.alpha = 1;
-        permanentPopUpView.alpha = 0.7;
+    if (touchPopUp) {
+        if (!self.usingCustomPopupView) {
+            [UIView animateWithDuration:0.2f delay:0 options:UIViewAnimationOptionCurveEaseOut animations:^{
+                self.popUpLabel.alpha = 0.7f;
+            } completion:nil];
+        }
+    } else if (self.animationGraphEntranceTime <= 0) {
+        popUpLabel.alpha = 1;
     } else {
-        [UIView animateWithDuration:0.5 delay:self.animationGraphEntranceTime options:UIViewAnimationOptionCurveLinear animations:^{
-            permanentPopUpLabel.alpha = 1;
-            permanentPopUpView.alpha = 0.7;
+        [UIView animateWithDuration:0.5f delay:self.animationGraphEntranceTime options:UIViewAnimationOptionCurveLinear animations:^{
+            popUpLabel.alpha = 1;
         } completion:nil];
     }
+    return popUpLabel;
 }
 
-- (BOOL)checkOverlapsForView:(UIView *)view {
-    for (UIView *viewForLabel in [self subviews]) {
-        if ([viewForLabel isKindOfClass:[UIView class]] && viewForLabel.tag == PermanentPopUpViewTag3100 ) {
-            if ((viewForLabel.frame.origin.x + viewForLabel.frame.size.width) >= view.frame.origin.x) {
-                if (viewForLabel.frame.origin.y >= view.frame.origin.y && viewForLabel.frame.origin.y <= view.frame.origin.y + view.frame.size.height) return YES;
-                else if (viewForLabel.frame.origin.y + viewForLabel.frame.size.height >= view.frame.origin.y && viewForLabel.frame.origin.y + viewForLabel.frame.size.height <= view.frame.origin.y + view.frame.size.height) return YES;
-            }
-        }
-    }
-    return NO;
-}
 
 - (UIImage *)graphSnapshotImage {
     return [self graphSnapshotImageRenderedWhileInBackground:NO];
@@ -1115,120 +1066,94 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
 
 - (UIImage *)graphSnapshotImageRenderedWhileInBackground:(BOOL)appIsInBackground {
     UIGraphicsBeginImageContextWithOptions(self.bounds.size, NO, [UIScreen mainScreen].scale);
-    
-    if (appIsInBackground == NO) [self drawViewHierarchyInRect:self.bounds afterScreenUpdates:YES];
-    else [self.layer renderInContext:UIGraphicsGetCurrentContext()];
-    
+
+    if (appIsInBackground == NO) {
+        [self drawViewHierarchyInRect:self.bounds afterScreenUpdates:YES];
+    } else {
+        CGContextRef context = UIGraphicsGetCurrentContext();
+        if (context) [self.layer renderInContext:context];
+    }
     UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
     UIGraphicsEndImageContext();
-    
+
     return image;
 }
 
 #pragma mark - Data Source
 
 - (void)reloadGraph {
-    for (UIView *subviews in self.subviews) {
-        [subviews removeFromSuperview];
-    }
     [self drawGraph];
-//    [self setNeedsLayout];
+    //    [self setNeedsLayout];
 }
 
 #pragma mark - Calculations
 
-- (NSArray *)calculationDataPoints {
-    NSPredicate *filter = [NSPredicate predicateWithBlock:^BOOL(id evaluatedObject, NSDictionary *bindings) {
-        NSNumber *value = (NSNumber *)evaluatedObject;
-        BOOL retVal = ![value isEqualToNumber:@(BEMNullGraphValue)];
-        return retVal;
+- (NSArray <NSNumber *> *)calculationDataPoints {
+    NSPredicate *filter = [NSPredicate predicateWithBlock:^BOOL(NSNumber * value, NSDictionary *bindings) {
+        return ![value  isEqualToNumber:@(BEMNullGraphValue)];
     }];
-    NSArray *filteredArray = [dataPoints filteredArrayUsingPredicate:filter];
+    NSArray <NSNumber *> *filteredArray = [dataPoints filteredArrayUsingPredicate:filter];
     return filteredArray;
 }
 
+- (NSNumber *)calculatePointValueMode {
+    NSArray <NSNumber *> *filteredArray = [self calculationDataPoints];
+    if (filteredArray.count == 0) return @(NAN);
+
+    NSExpression *expression = [NSExpression expressionForFunction:@"mode:" arguments:@[[NSExpression expressionForConstantValue:filteredArray]]];
+    NSArray <NSNumber *> *value = [expression expressionValueWithObject:nil context:nil];
+    NSNumber * result = [value respondsToSelector:@selector(firstObject)] ? [value firstObject] : nil;
+    return (result ?: @(NAN));
+}
+
+-(NSNumber *) calculateExpression:(NSString *) function {
+    NSArray <NSNumber *> *filteredArray = [self calculationDataPoints];
+    if (filteredArray.count == 0) return @(NAN);
+    NSExpression *expression = [NSExpression expressionForFunction:function arguments:@[[NSExpression expressionForConstantValue:filteredArray]]];
+    return [expression expressionValueWithObject:nil context:nil];
+}
+
 - (NSNumber *)calculatePointValueAverage {
-    NSArray *filteredArray = [self calculationDataPoints];
-    if (filteredArray.count == 0) return 0;
-    
-    NSExpression *expression = [NSExpression expressionForFunction:@"average:" arguments:@[[NSExpression expressionForConstantValue:filteredArray]]];
-    NSNumber *value = [expression expressionValueWithObject:nil context:nil];
-    
-    return value;
+    return [self calculateExpression:@"average:"];
 }
 
 - (NSNumber *)calculatePointValueSum {
-    NSArray *filteredArray = [self calculationDataPoints];
-    if (filteredArray.count == 0) return 0;
-    
-    NSExpression *expression = [NSExpression expressionForFunction:@"sum:" arguments:@[[NSExpression expressionForConstantValue:filteredArray]]];
-    NSNumber *value = [expression expressionValueWithObject:nil context:nil];
-    
-    return value;
+    return [self calculateExpression:@"sum:"];
 }
 
 - (NSNumber *)calculatePointValueMedian {
-    NSArray *filteredArray = [self calculationDataPoints];
-    if (filteredArray.count == 0) return 0;
-    
-    NSExpression *expression = [NSExpression expressionForFunction:@"median:" arguments:@[[NSExpression expressionForConstantValue:filteredArray]]];
-    NSNumber *value = [expression expressionValueWithObject:nil context:nil];
-    
-    return value;
-}
-
-- (NSNumber *)calculatePointValueMode {
-    NSArray *filteredArray = [self calculationDataPoints];
-    if (filteredArray.count == 0) return 0;
-    
-    NSExpression *expression = [NSExpression expressionForFunction:@"mode:" arguments:@[[NSExpression expressionForConstantValue:filteredArray]]];
-    NSMutableArray *value = [expression expressionValueWithObject:nil context:nil];
-    
-    return [value firstObject];
+    return [self calculateExpression:@"median:"];
 }
 
 - (NSNumber *)calculateLineGraphStandardDeviation {
-    NSArray *filteredArray = [self calculationDataPoints];
-    if (filteredArray.count == 0) return 0;
-    
-    NSExpression *expression = [NSExpression expressionForFunction:@"stddev:" arguments:@[[NSExpression expressionForConstantValue:filteredArray]]];
-    NSNumber *value = [expression expressionValueWithObject:nil context:nil];
-    
-    return value;
+    return [self calculateExpression:@"stddev:"];
 }
 
 - (NSNumber *)calculateMinimumPointValue {
-    NSArray *filteredArray = [self calculationDataPoints];
-    if (filteredArray.count == 0) return 0;
-    
-    NSExpression *expression = [NSExpression expressionForFunction:@"min:" arguments:@[[NSExpression expressionForConstantValue:filteredArray]]];
-    NSNumber *value = [expression expressionValueWithObject:nil context:nil];
-    return value;
+    return [self calculateExpression:@"min:"];
 }
 
 - (NSNumber *)calculateMaximumPointValue {
-    NSArray *filteredArray = [self calculationDataPoints];
-    if (filteredArray.count == 0) return 0;
-    
-    NSExpression *expression = [NSExpression expressionForFunction:@"max:" arguments:@[[NSExpression expressionForConstantValue:filteredArray]]];
-    NSNumber *value = [expression expressionValueWithObject:nil context:nil];
-    
-    return value;
-}
+    return [self calculateExpression:@"max:"];
+ }
 
 
 #pragma mark - Values
 
-- (NSArray *)graphValuesForXAxis {
+- (NSArray <NSString *> *)graphValuesForXAxis {
     return xAxisValues;
 }
 
-- (NSArray *)graphValuesForDataPoints {
+- (NSArray <NSNumber *> *)graphValuesForDataPoints {
     return dataPoints;
 }
 
-- (NSArray *)graphLabelsForXAxis {
-    return xAxisLabels;
+- (NSArray <UILabel *> *)graphLabelsForXAxis {
+    return self.xAxisLabels;
+}
+
+- (NSArray <UILabel *> *)graphLabelsForYAxis {
+    return self.yAxisLabels;
 }
 
 - (void)setAnimationGraphStyle:(BEMLineAnimation)animationGraphStyle {
@@ -1247,142 +1172,75 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
             return fabs(translation.y) < fabs(translation.x);
         } else return NO;
         return YES;
-    } else return NO;
+    } else return [super gestureRecognizerShouldBegin:gestureRecognizer];
 }
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
-	    return YES;
+    return YES;
 }
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(UITouch *)touch {
-	    return YES;
+    return YES;
 }
 
 - (void)handleGestureAction:(UIGestureRecognizer *)recognizer {
     CGPoint translation = [recognizer locationInView:self.viewForBaselineLayout];
-    
+
     if (!((translation.x + self.frame.origin.x) <= self.frame.origin.x) && !((translation.x + self.frame.origin.x) >= self.frame.origin.x + self.frame.size.width)) { // To make sure the vertical line doesn't go beyond the frame of the graph.
         self.touchInputLine.frame = CGRectMake(translation.x - self.widthTouchInputLine/2, 0, self.widthTouchInputLine, self.frame.size.height);
     }
-    
+
     self.touchInputLine.alpha = self.alphaTouchInputLine;
-    
-    closestDot = [self closestDotFromtouchInputLine:self.touchInputLine];
-    closestDot.alpha = 0.8;
-    
-    
-    if (self.enablePopUpReport == YES && closestDot.tag >= DotFirstTag100 && closestDot.tag < DotLastTag1000 && [closestDot isKindOfClass:[BEMCircle class]] && self.alwaysDisplayPopUpLabels == NO) {
-        [self setUpPopUpLabelAbovePoint:closestDot];
+
+    BEMCircle *closestDot = [self closestDotFromtouchInputLine:self.touchInputLine];
+    closestDot.alpha = 0.8f;
+
+
+    if (self.enablePopUpReport == YES && closestDot.tag >= DotFirstTag100 && [closestDot isKindOfClass:[BEMCircle class]] && self.alwaysDisplayPopUpLabels == NO) {
+        [self labelForPoint:closestDot reuseNumber:NSIntegerMax];
     }
-    
-    if (closestDot.tag >= DotFirstTag100 && closestDot.tag < DotLastTag1000 && [closestDot isMemberOfClass:[BEMCircle class]]) {
+
+    if (closestDot.tag >= DotFirstTag100  && [closestDot isMemberOfClass:[BEMCircle class]]) {
         if ([self.delegate respondsToSelector:@selector(lineGraph:didTouchGraphWithClosestIndex:)] && self.enableTouchReport == YES) {
-            [self.delegate lineGraph:self didTouchGraphWithClosestIndex:((NSInteger)closestDot.tag - DotFirstTag100)];
+            [self.delegate lineGraph:self didTouchGraphWithClosestIndex:((NSUInteger)closestDot.tag - DotFirstTag100)];
+
         }
     }
-    
+
     // ON RELEASE
     if (recognizer.state == UIGestureRecognizerStateEnded) {
         if ([self.delegate respondsToSelector:@selector(lineGraph:didReleaseTouchFromGraphWithClosestIndex:)]) {
             [self.delegate lineGraph:self didReleaseTouchFromGraphWithClosestIndex:(closestDot.tag - DotFirstTag100)];
+
         }
-        
+
         [UIView animateWithDuration:0.2 delay:0 options:UIViewAnimationOptionCurveEaseOut animations:^{
             if (self.alwaysDisplayDots == NO && self.displayDotsOnly == NO) {
                 closestDot.alpha = 0;
             }
-            
+
             self.touchInputLine.alpha = 0;
             if (self.enablePopUpReport == YES) {
-                self.popUpView.alpha = 0;
                 self.popUpLabel.alpha = 0;
-//                self.customPopUpView.alpha = 0;
+                //                self.customPopUpView.alpha = 0;
             }
         } completion:nil];
-    }
-}
-
-- (CGFloat)distanceToClosestPoint {
-    return sqrt(pow(closestDot.center.x - self.touchInputLine.center.x, 2));
-}
-
-- (void)setUpPopUpLabelAbovePoint:(BEMCircle *)closestPoint {
-    self.xCenterLabel = closestDot.center.x;
-    self.yCenterLabel = closestDot.center.y - closestDot.frame.size.height/2 - 15;
-    self.popUpView.center = CGPointMake(self.xCenterLabel, self.yCenterLabel);
-    self.popUpLabel.center = self.popUpView.center;
-    int index = (int)(closestDot.tag - DotFirstTag100);
-
-    if ([self.delegate respondsToSelector:@selector(lineGraph:modifyPopupView:forIndex:)]) {
-        [self.delegate lineGraph:self modifyPopupView:self.popUpView forIndex:index];
-    }
-    self.xCenterLabel = closestDot.center.x;
-    self.yCenterLabel = closestDot.center.y - closestDot.frame.size.height/2 - 15;
-    self.popUpView.center = CGPointMake(self.xCenterLabel, self.yCenterLabel);
-
-    self.popUpView.alpha = 1.0;
-    
-    CGPoint popUpViewCenter = CGPointZero;
-    
-    if ([self.delegate respondsToSelector:@selector(popUpSuffixForlineGraph:)])
-        self.popUpLabel.text = [NSString stringWithFormat:@"%li%@", (long)[dataPoints[(NSInteger) closestDot.tag - DotFirstTag100] integerValue], [self.delegate popUpSuffixForlineGraph:self]];
-    else
-        self.popUpLabel.text = [NSString stringWithFormat:@"%li", (long)[dataPoints[(NSInteger) closestDot.tag - DotFirstTag100] integerValue]];
-    
-    if (self.enableYAxisLabel == YES && self.popUpView.frame.origin.x <= self.YAxisLabelXOffset && !self.positionYAxisRight) {
-        self.xCenterLabel = self.popUpView.frame.size.width/2;
-        popUpViewCenter = CGPointMake(self.xCenterLabel + self.YAxisLabelXOffset + 1, self.yCenterLabel);
-    } else if ((self.popUpView.frame.origin.x + self.popUpView.frame.size.width) >= self.frame.size.width - self.YAxisLabelXOffset && self.positionYAxisRight) {
-        self.xCenterLabel = self.frame.size.width - self.popUpView.frame.size.width/2;
-        popUpViewCenter = CGPointMake(self.xCenterLabel - self.YAxisLabelXOffset, self.yCenterLabel);
-    } else if (self.popUpView.frame.origin.x <= 0) {
-        self.xCenterLabel = self.popUpView.frame.size.width/2;
-        popUpViewCenter = CGPointMake(self.xCenterLabel, self.yCenterLabel);
-    } else if ((self.popUpView.frame.origin.x + self.popUpView.frame.size.width) >= self.frame.size.width) {
-        self.xCenterLabel = self.frame.size.width - self.popUpView.frame.size.width/2;
-        popUpViewCenter = CGPointMake(self.xCenterLabel, self.yCenterLabel);
-    }
-    
-    if (self.popUpView.frame.origin.y <= 2) {
-        self.yCenterLabel = closestDot.center.y + closestDot.frame.size.height/2 + 15;
-        popUpViewCenter = CGPointMake(self.xCenterLabel, closestDot.center.y + closestDot.frame.size.height/2 + 15);
-    }
-
-    if (!CGPointEqualToPoint(popUpViewCenter, CGPointZero)) {
-        self.popUpView.center = popUpViewCenter;
-    }
-    
-    if (!self.usingCustomPopupView) {
-        [UIView animateWithDuration:0.2 delay:0 options:UIViewAnimationOptionCurveEaseOut animations:^{
-            self.popUpView.alpha = 0.7;
-            self.popUpLabel.alpha = 1;
-        } completion:nil];
-        NSString *prefix = @"";
-        NSString *suffix = @"";
-        if ([self.delegate respondsToSelector:@selector(popUpSuffixForlineGraph:)]) {
-            suffix = [self.delegate popUpSuffixForlineGraph:self];
-        }
-        if ([self.delegate respondsToSelector:@selector(popUpPrefixForlineGraph:)]) {
-            prefix = [self.delegate popUpPrefixForlineGraph:self];
-        }
-        NSNumber *value = dataPoints[index];
-        NSString *formattedValue = [NSString stringWithFormat:self.formatStringForValues, value.doubleValue];
-        self.popUpLabel.text = [NSString stringWithFormat:@"%@%@%@", prefix, formattedValue, suffix];
-        self.popUpLabel.center = self.popUpView.center;
     }
 }
 
 #pragma mark - Graph Calculations
 
 - (BEMCircle *)closestDotFromtouchInputLine:(UIView *)touchInputLine {
-    currentlyCloser = CGFLOAT_MAX;
-    for (BEMCircle *point in self.subviews) {
-        if (point.tag >= DotFirstTag100 && point.tag < DotLastTag1000 && [point isMemberOfClass:[BEMCircle class]]) {
+    BEMCircle * closestDot = nil;
+    CGFloat currentlyCloser = CGFLOAT_MAX;
+    for (BEMCircle *point in self.circleDots) {
+        if (point.tag >= DotFirstTag100) {
             if (self.alwaysDisplayDots == NO && self.displayDotsOnly == NO) {
                 point.alpha = 0;
             }
-            if (pow(((point.center.x) - touchInputLine.center.x), 2) < currentlyCloser) {
-                currentlyCloser = pow(((point.center.x) - touchInputLine.center.x), 2);
+            CGFloat distance = (CGFloat)fabs(point.center.x - touchInputLine.center.x) ;
+            if (distance < currentlyCloser) {
+                currentlyCloser = distance;
                 closestDot = point;
             }
         }
@@ -1396,14 +1254,14 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
     } else {
         CGFloat dotValue;
         CGFloat maxValue = -FLT_MAX;
-        
+
         @autoreleasepool {
-            for (int i = 0; i < numberOfPoints; i++) {
+            for (NSUInteger i = 0; i < numberOfPoints; i++) {
                 if ([self.dataSource respondsToSelector:@selector(lineGraph:valueForPointAtIndex:)]) {
                     dotValue = [self.dataSource lineGraph:self valueForPointAtIndex:i];
                 } else dotValue = 0;
-                
-                if (dotValue == BEMNullGraphValue) continue;
+
+                if (dotValue >= BEMNullGraphValue) continue;
                 if (dotValue > maxValue) maxValue = dotValue;
             }
         }
@@ -1417,15 +1275,15 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
     } else {
         CGFloat dotValue;
         CGFloat minValue = INFINITY;
-        
+
         @autoreleasepool {
-            for (int i = 0; i < numberOfPoints; i++) {
+            for (NSUInteger i = 0; i < numberOfPoints; i++) {
                 if ([self.dataSource respondsToSelector:@selector(lineGraph:valueForPointAtIndex:)]) {
                     dotValue = [self.dataSource lineGraph:self valueForPointAtIndex:i];
-                    
+
                 } else dotValue = 0;
-                
-                if (dotValue == BEMNullGraphValue) continue;
+
+                if (dotValue >= BEMNullGraphValue) continue;
                 if (dotValue < minValue) minValue = dotValue;
             }
         }
@@ -1434,44 +1292,37 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
 }
 
 - (CGFloat)yPositionForDotValue:(CGFloat)dotValue {
-    if (dotValue == BEMNullGraphValue) {
+    if (dotValue >= BEMNullGraphValue) {
         return BEMNullGraphValue;
     }
-    
+
     CGFloat positionOnYAxis; // The position on the Y-axis of the point currently being created.
-    CGFloat padding = self.frame.size.height/2;
-    if (padding > 90.0) {
-        padding = 90.0;
-    }
+    CGFloat padding = MIN(90.0f,self.frame.size.height/2);
 
-    if ([self.delegate respondsToSelector:@selector(staticPaddingForLineGraph:)])
+    if ([self.delegate respondsToSelector:@selector(staticPaddingForLineGraph:)]) {
         padding = [self.delegate staticPaddingForLineGraph:self];
-
-    if (self.enableXAxisLabel) {
-        if ([self.dataSource respondsToSelector:@selector(lineGraph:labelOnXAxisForIndex:)]) {
-            if ([xAxisLabels count] > 0) {
-                UILabel *label = [xAxisLabels objectAtIndex:0];
-                self.XAxisLabelYOffset = label.frame.size.height + self.widthLine;
-            }
-        }
     }
-    
-    if (self.minValue == self.maxValue && self.autoScaleYAxis == YES) positionOnYAxis = self.frame.size.height/2;
-    else if (self.autoScaleYAxis == YES) positionOnYAxis = ((self.frame.size.height - padding/2) - ((dotValue - self.minValue) / ((self.maxValue - self.minValue) / (self.frame.size.height - padding)))) + self.XAxisLabelYOffset/2;
-    else positionOnYAxis = ((self.frame.size.height) - dotValue);
-    
+
+    self.XAxisLabelYOffset = self.enableXAxisLabel ? self.backgroundXAxis.frame.size.height : 0.0f;
+
+    if (self.autoScaleYAxis) {
+        if (self.minValue >= self.maxValue ) {
+            positionOnYAxis = self.frame.size.height/2.0f;
+        } else {
+            CGFloat percentValue = (dotValue - self.minValue) / (self.maxValue - self.minValue);
+            CGFloat topOfChart = self.frame.size.height - padding/2.0f;
+            CGFloat sizeOfChart = self.frame.size.height - padding;
+            positionOnYAxis = topOfChart - percentValue * sizeOfChart + self.XAxisLabelYOffset/2;
+        }
+    } else {
+        positionOnYAxis = ((self.frame.size.height) - dotValue);
+    }
     positionOnYAxis -= self.XAxisLabelYOffset;
     
     return positionOnYAxis;
 }
 
-#pragma mark - Customization Methods
-
-- (void)setColorTouchInputLine:(UIColor *)colorTouchInputLine {
-    _colorTouchInputLine = colorTouchInputLine;
-}
-
-#pragma mark - Other Methods
+#pragma mark - Deprecated Methods
 
 - (void)printDeprecationAndUnavailableWarningForOldMethod:(NSString *)oldMethod {
     NSLog(@"[BEMSimpleLineGraph] UNAVAILABLE, DEPRECATION ERROR. The delegate method, %@, is both deprecated and unavailable. It is now a data source method. You must implement this method from BEMSimpleLineGraphDataSource. Update your delegate method as soon as possible. One of two things will now happen: A) an exception will be thrown, or B) the graph will not load.", oldMethod);

--- a/Sample Project/SimpleLineChart.xcodeproj/project.pbxproj
+++ b/Sample Project/SimpleLineChart.xcodeproj/project.pbxproj
@@ -408,6 +408,14 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
+				WARNING_CFLAGS = (
+					"-Weverything",
+					"-Wundef",
+					"-Wextra",
+					"-Wno-unused-parameter",
+					"-Wno-objc-missing-property-synthesis",
+					"-Wpartial-availability",
+				);
 			};
 			name = Debug;
 		};
@@ -454,6 +462,17 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "BorisEmorine.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				WARNING_CFLAGS = (
+					"$(inherited)",
+					"-Wno-documentation-unknown-command",
+					"-Wno-direct-ivar-access",
+					"-Wno-objc-missing-property-synthesis",
+					"-Wno-double-promotion",
+					"-Wno-auto-import",
+					"-Wno-incomplete-module",
+					"-Wno-assign-enum",
+					"-Wno-gnu",
+				);
 				WRAPPER_EXTENSION = app;
 			};
 			name = Debug;
@@ -477,6 +496,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/SimpleLineChart.app/SimpleLineChart";
+				CLANG_WARN_OBJC_MISSING_PROPERTY_SYNTHESIS = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -492,6 +512,17 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "BorisEmorine.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
+				WARNING_CFLAGS = (
+					"$(inherited)",
+					"-Wno-documentation-unknown-command",
+					"-Wno-direct-ivar-access",
+					"-Wno-objc-missing-property-synthesis",
+					"-Wno-double-promotion",
+					"-Wno-auto-import",
+					"-Wno-incomplete-module",
+					"-Wno-gnu",
+					"-Wno-assign-enum",
+				);
 				WRAPPER_EXTENSION = xctest;
 			};
 			name = Debug;
@@ -500,6 +531,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				BUNDLE_LOADER = "$(BUILT_PRODUCTS_DIR)/SimpleLineChart.app/SimpleLineChart";
+				CLANG_WARN_OBJC_MISSING_PROPERTY_SYNTHESIS = NO;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(SDKROOT)/Developer/Library/Frameworks",
 					"$(inherited)",
@@ -511,6 +543,16 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "BorisEmorine.${PRODUCT_NAME:rfc1034identifier}";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				TEST_HOST = "$(BUNDLE_LOADER)";
+				WARNING_CFLAGS = (
+					"$(inherited)",
+					"-Wno-documentation-unknown-command",
+					"-Wno-direct-ivar-access",
+					"-Wno-objc-missing-property-synthesis",
+					"-Wno-double-promotion",
+					"-Wno-auto-import",
+					"-Wno-incomplete-module",
+					"-Wno-assign-enum",
+				);
 				WRAPPER_EXTENSION = xctest;
 			};
 			name = Release;

--- a/Sample Project/SimpleLineChart/SimpleLineChart-Prefix.pch
+++ b/Sample Project/SimpleLineChart/SimpleLineChart-Prefix.pch
@@ -4,7 +4,7 @@
 //  The contents of this file are implicitly included at the beginning of every source file.
 //
 
-#import <Availability.h>
+@import Darwin.Availability;
 
 #ifndef __IPHONE_5_0
 #warning "This project uses features only available in iOS SDK 5.0 and later."

--- a/Sample Project/SimpleLineChartTests/SimpleLineChartTests.m
+++ b/Sample Project/SimpleLineChartTests/SimpleLineChartTests.m
@@ -7,19 +7,19 @@
 //
 
 @import XCTest;
+#pragma GCC diagnostic ignored "-Wfloat-equal"
+
 #import "BEMSimpleLineGraphView.h"
 #import "contantsTests.h"
 
-/// Same tags as in BEMSimpleLineGraphView.m
-typedef NS_ENUM(NSInteger, BEMInternalTags)
-{
-    DotFirstTag100 = 100,
-    DotLastTag1000 = 1000,
-    LabelYAxisTag2000 = 2000,
-    BackgroundYAxisTag2100 = 2100,
-    BackgroundXAxisTag2200 = 2200,
-    PermanentPopUpViewTag3100 = 3100,
-};
+@interface BEMSimpleLineGraphView ()
+//allow tester to get to internal properties
+
+/// All of the dataPoint dots
+@property (strong, nonatomic) NSMutableArray <BEMCircle *> *circleDots;
+
+@end
+
 
 /// General, simple tests for BEMSimpleLineGraph. Mostly testing default values.
 @interface SimpleLineGraphTests : XCTestCase <BEMSimpleLineGraphDelegate, BEMSimpleLineGraphDataSource>
@@ -41,15 +41,15 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
 
 #pragma mark BEMSimpleLineGraph Data Source
 
-- (NSInteger)numberOfPointsInLineGraph:(BEMSimpleLineGraphView * __nonnull)graph {
+- (NSUInteger)numberOfPointsInLineGraph:(BEMSimpleLineGraphView * __nonnull)graph {
     return numberOfPoints;
 }
 
-- (CGFloat)lineGraph:(BEMSimpleLineGraphView * __nonnull)graph valueForPointAtIndex:(NSInteger)index {
+- (CGFloat)lineGraph:(BEMSimpleLineGraphView * __nonnull)graph valueForPointAtIndex:(NSUInteger)index {
     return pointValue;
 }
 
-- (NSString *)lineGraph:(nonnull BEMSimpleLineGraphView *)graph labelOnXAxisForIndex:(NSInteger)index {
+- (NSString *)lineGraph:(nonnull BEMSimpleLineGraphView *)graph labelOnXAxisForIndex:(NSUInteger)index {
     return xAxisLabelString;
 }
 
@@ -88,7 +88,7 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
     XCTAssert(values.count == numberOfPoints, @"The number of data points should be equal to the number returned by the data source method 'numberOfPointsInLineGraph:'");
     
     NSMutableArray *mockedValues = [NSMutableArray new];
-    for (NSInteger i = 0; i < numberOfPoints; i++) {
+    for (NSUInteger i = 0; i < numberOfPoints; i++) {
         [mockedValues addObject:[NSNumber numberWithFloat:pointValue]];
     }
     XCTAssert([values isEqualToArray:mockedValues], @"The array returned by 'graphValuesForDataPoints' should be similar than the one returned by the data source method 'valueForPointAtIndex:'labelOnXAxisForIndex:");
@@ -98,12 +98,8 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
     self.lineGraph.animationGraphEntranceTime = 0.0;
     [self.lineGraph reloadGraph];
     
-    NSMutableArray *dots = [NSMutableArray new];
-    for (UIView *dot in self.lineGraph.subviews) {
-        if ([dot isKindOfClass:[BEMCircle class]] && dot.tag >= DotFirstTag100 && dot.tag <= DotLastTag1000) {
-            [dots addObject:dot];
-        }
-    }
+    NSMutableArray *dots = self.lineGraph.circleDots;
+
     XCTAssert(dots.count == numberOfPoints, @"There should be as many BEMCircle views in the graph's subviews as the data source method 'numberOfPointsInLineGraph:' returns");
     
     for (BEMCircle *dot in dots) {
@@ -120,7 +116,7 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
     self.lineGraph.enableXAxisLabel = NO;
     [self.lineGraph reloadGraph];
     
-    XCTAssert([self.lineGraph graphLabelsForXAxis].count == 0);
+    XCTAssert([self.lineGraph graphLabelsForXAxis].count == 0, @"Should be no labels on XAxis");
     
     self.lineGraph.enableXAxisLabel = YES;
     [self.lineGraph reloadGraph];
@@ -131,34 +127,31 @@ typedef NS_ENUM(NSInteger, BEMInternalTags)
     for (UILabel *XAxisLabel in labels) {
         XCTAssert([XAxisLabel isMemberOfClass:[UILabel class]], @"The array returned by 'graphLabelsForXAxis' should only return UILabels");
         XCTAssert([XAxisLabel.text isEqualToString:xAxisLabelString], @"The X-Axis label's strings should be the same as the one returned by the data source method 'labelOnXAxisForIndex:'");
-        XCTAssert([XAxisLabel.backgroundColor isEqual:[UIColor clearColor]], @"X-Axis labels are expected to have a clear beackground color by default");
+        XCTAssert([XAxisLabel.backgroundColor isEqual:[UIColor clearColor]], @"X-Axis labels are expected to have a clear background color by default");
         XCTAssert([XAxisLabel.textColor isEqual:[UIColor blackColor]], @"X-Axis labels are expected to have a black text color by default");
         XCTAssert(XAxisLabel.textAlignment == NSTextAlignmentCenter, @"X-Axis labels are expected to have their text centered by default");
-        XCTAssert(XAxisLabel.tag == DotLastTag1000, @"X-Axis labels are expected to have a certain tag by default");
     }
 }
 
 - (void)testYAxisLabels {
     self.lineGraph.enableYAxisLabel = NO;
     [self.lineGraph reloadGraph];
-    
-    for (UILabel *label in self.lineGraph.subviews) {
-        XCTAssert(label.tag != LabelYAxisTag2000, @"No Y-Axis labels are expected if enableYAxisLabel is set to NO");
-    }
-    
+
+    XCTAssert([self.lineGraph graphLabelsForYAxis].count == 0, @"No Y-Axis labels are expected if enableYAxisLabel is set to NO");
+
+
     self.lineGraph.enableYAxisLabel = YES;
     [self.lineGraph reloadGraph];
     
     NSString *value = [NSString stringWithFormat:@"%.f", pointValue];
-    
-    NSMutableArray *yAxisLabels = [NSMutableArray new];
-    for (UILabel *label in self.lineGraph.subviews) {
-        if ([label isKindOfClass:[UILabel class]] && label.tag == LabelYAxisTag2000) {
+    NSMutableArray * yAxisLabels = [NSMutableArray array];
+    for (UILabel *label in [self.lineGraph graphLabelsForYAxis]) {
+        if (label.superview) {
             [yAxisLabels addObject:label];
-            XCTAssert([label.text isEqualToString:value], @"The value on the Y-Axis label is expected to be the value given by the data source method 'valueForPointAtIndex:'");
-            XCTAssert([label.textColor isEqual:[UIColor blackColor]], @"The Y-Axis label is expected to have a text color of black by default");
-            XCTAssert([label.backgroundColor isEqual:[UIColor clearColor]], @"The Y-Axis label is expected to have a backgrounf color of clear by default");
         }
+        XCTAssert([label.text isEqualToString:value], @"The value on the Y-Axis label is expected to be the value given by the data source method 'valueForPointAtIndex:'");
+        XCTAssert([label.textColor isEqual:[UIColor blackColor]], @"The Y-Axis label is expected to have a text color of black by default");
+        XCTAssert([label.backgroundColor isEqual:[UIColor clearColor]], @"The Y-Axis label is expected to have a background color of clear by default");
     }
     
     XCTAssert(yAxisLabels.count == 1, @"With all the dots having the same value, we only expect one Y axis label");

--- a/Sample Project/SimpleLineChartTests/contantsTests.h
+++ b/Sample Project/SimpleLineChartTests/contantsTests.h
@@ -9,7 +9,7 @@
 #ifndef SimpleLineChart_contantsTests_h
 #define SimpleLineChart_contantsTests_h
 
-static NSInteger numberOfPoints = 100;
+static NSUInteger numberOfPoints = 100;
 static CGFloat pointValue = 3.0;
 static NSString * xAxisLabelString = @"X-Axis-Label";
 static NSString * popUpPrefix = @"Prefix";


### PR DESCRIPTION
### Summary

First, thanks for a very nice project. I realize this is a weird PR. In order to fix a rotation issue (due to labels being regenerated every time), I changed to tracking the subviews, but did that in my own personal repo. In order to do that, as I was understanding each component, I refactored to avoid duplicate code.

I wasn't planning to submit it, just did it for my own use, then I noticed requests to remove the tag dependency. So, I re-pulled from your Feature version and generated a new commit with all my changes in it. My guess is you're not going to like the extent of my refactoring or the testing that would be required, but thought I'd offer it.  If you do want to incorporate some or all of this, but are offended by the obviously massive commit, I'm willing to go back through and break it up into smaller commits and do further testing.  
### Fixes Issues

This pull request fixes the following issues:  
- Reuses views when possible to make rotation work properly (and 40% better reload performance)
- Leaking UIViews during rotation
- A few typos in documentation
- Added nullability to BEMLine.h, circle etc
- Combined label and background view for pouplabels
- Typo: Reference [sic.] misspelling corrected
- More consistency on prefix/suffix usage

Compiler warnings (for projects with `-WEverything`)
- Compiler warnings about CGFloat losing precision
- Compiler warnings about sign changing (uses NSUInteger when possible)
- Compiler warnings about using Formats as literals
### Changes

Features:  
- Removes all tags (except for mapping from dots back to values)
- Configurable y-axis title for Average line
- Refactored to remove redundant code
- Access to `graphLabelsForYAxis` (parallel to `graphLabelsForXAxis`)
### Notes
- [X] This pull request makes breaking changes, and if so, involves the following:  
  - [x] Public API availability  
  - [ ] Internal functionality or behavior  
- [X] I have run and ensured that this pull request passes all XCTests (as modified)

**Breaking Change Notes**
Breaking reference is to the use of `NSUInteger` in API to keep consistent sign usage throughout. Could be put back and use `NSInteger` internally instead. Otherwise, it will break any code that looks for tags (although they could be added back just for this reason) such as tests prior to modification.

_Additional Notes_
One known bug, I deleted and forgot to restore the `customPopup` delegate calls.
